### PR TITLE
Fully Built USA based EasyPost integration for erpNext

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ A USA-focused shipping integration for ERPNext using EasyPost (with UPS, USPS & 
 
 - **Fully Tested**  
   - EasyPost (https://www.easypost.com)  
-    - Supports FedEx third-party billing via your FedEx account credentials  
-    - **Note:** UPS third-party billing is _not_ supported through EasyPost—UPS labels must be created with direct UPS API calls.  
+    - Supports Standard UPS, FedEx & USPS shipping, FedEx third-party billing via EasyPost API & UPS 3rd Party Billing through user's UPS account
+    - **Note:** UPS third-party billing is _not_ supported through EasyPost. UPS labels must be created with direct UPS API calls.
 - **Self-hosted Connector**  
   - `ups_direct.py`  
     - Direct UPS integration  
-    - **Add your UPS credentials** (Access Key, User ID, Password) into the `ups_direct.py` config section  
+    - **Add your UPS credentials** (Access Key, User ID, UPS account number) into the (top) of `ups_direct.py` config section
 - **Planned / Untested**  
   - LetMeShip (https://www.letmeship.com)  
   - SendCloud (https://www.sendcloud.com)  
@@ -91,3 +91,21 @@ Click Fetch Shipping Rates.
 Compare rates in the dialog (preferred services appear first).
 
 Click Buy to book that service and create the shipment.
+
+Print Shipping Label
+Print Shipping Label: Opens the carrier-provided PDF or PNG in a new tab for your local printer.
+Network Print: Sends the PDF or PNG to your configured CUPS printer automatically.
+
+🛠️ Development
+Templates live under erpnext_shipping/public/templates/
+
+Client script: erpnext_shipping/public/js/shipment.js
+
+EasyPost integration: erpnext_shipping/erpnext_shipping/integrations/easypost.py
+
+UPS direct integration: erpnext_shipping/erpnext_shipping/integrations/ups_direct.py
+
+Run bench build && bench restart after making changes.
+
+📄 License
+MIT

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ A USA-focused shipping integration for ERPNext using EasyPost (with UPS, USPS & 
 
 > **Prerequisites**  
 > - An EasyPost API key  
-> - A UPS Developer account with a “Rating” & “Shipping” app (https://developer.ups.com)  
+> - A UPS Developer app with “Rating” & “Shipping” privlidges (https://developer.ups.com) 
+> - Add 5 custom fileds to shipment doc called:
+> - --custom_ship_on_third_party (Check) in list view
+> - --custom_third_party_account (Data) depends on eval:doc.custom_ship_on_third_party;
+> - --custom_third_party_postal (Data) depends on eval:doc.custom_ship_on_third_party;
+> - --custom_shipping_label (Data) hidden
+> - --custom_postage_label (Text) hidden
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,49 +1,93 @@
-## ERPNext Shipping
+# ERPNext Shipping Integration
 
-A Shipping Integration for ERPNext with various platforms. Platforms integrated in this app are:
+A USA-focused shipping integration for ERPNext using EasyPost (with UPS, USPS & FedEx support).  
 
-- [LetMeShip](https://www.letmeship.com/en/)
-- [SendCloud](https://www.sendcloud.com/home-new/)
+> **Prerequisites**  
+> - An EasyPost API key  
+> - A UPS Developer account with a “Rating” & “Shipping” app (https://developer.ups.com)  
 
-> [!TIP]
-> Please make sure to get your API access enabled first, by contacting the LetMeShip support.
+---
 
-## Features
-- Creation of shipment to a carrier service (e.g. FedEx, UPS) via LetMeShip and SendCloud. 
-- Compare shipping rates. 
-- Printing the shipping label is also made available within the Shipment doctype.
-- Templates for the parcel dimensions.
-- Shipment tracking.
+## 🚀 Features
 
-## Installation
+- **Rate Comparison**  
+  Fetch and compare live shipping rates from multiple carriers (UPS, USPS, FedEx) via EasyPost.  
+- **Preferred Services**  
+  Mark your most‐used carrier-service combinations and surface them at the top.  
+- **One-Click Shipment Creation**  
+  Create an ERPNext Shipment record and an EasyPost shipment in one step.  
+- **Label Printing**  
+  • **Local**: Opens the PDF in a new tab for your browser’s print dialog  
+  • **Network**: Send labels directly to a CUPS printer on your network  
+- **Dimension Templates**  
+  Save and reuse common box or pallet dimensions.  
+- **Tracking & Status**  
+  Automatically pull tracking numbers into the Shipment record.  
 
-Install [on Frappe Cloud](https://frappecloud.com/marketplace/apps/shipping) or your own server:
+---
 
+## 🔌 Integrations
+
+- **Fully Tested**  
+  - EasyPost (https://www.easypost.com)  
+    - Supports FedEx third-party billing via your FedEx account credentials  
+    - **Note:** UPS third-party billing is _not_ supported through EasyPost—UPS labels must be created with direct UPS API calls.  
+- **Self-hosted Connector**  
+  - `ups_direct.py`  
+    - Direct UPS integration  
+    - **Add your UPS credentials** (Access Key, User ID, Password) into the `ups_direct.py` config section  
+- **Planned / Untested**  
+  - LetMeShip (https://www.letmeship.com)  
+  - SendCloud (https://www.sendcloud.com)  
+
+---
+
+## 📦 Installation
+
+### 1. Frappe Cloud  
+Install directly from the [Frappe Cloud Marketplace](https://frappecloud.com/marketplace/apps/shipping).
+
+### 2. Self-Hosted Bench  
 ```bash
-cd ~/frappe-bench
-bench get-app https://github.com/frappe/erpnext-shipping.git --branch version-14
-bench --site $MY_SITE install-app erpnext_shipping
-```
+# From your bench directory
+bench get-app https://github.com/your-org/erpnext_shipping.git
+bench --site [your-site] install-app erpnext_shipping
+bench build
+bench restart
 
-## Setup
+⚙️ Configuration
+Shipping Settings
 
-Some shipping providers require the contact details of the pickup contact. Please make sure that the **User** selected as the _Pickup Contact Person_ has a first name, last name, email address, and phone number before submitting the **Shipment**.
+Navigate to Home > Settings > Shipping Settings
 
-For the 'compare shipping rates' feature to work as expected, you need to generate an API key from your service provider. Service providers have their own specific doctypes similar to those from the `Integrations`. They can be enabled or disabled depending on your needs.
+Enter your EasyPost API key, default network printer, and any preferred services.
 
-![LetMeShip 2020-08-05 09-54-28](https://user-images.githubusercontent.com/17470909/89377411-500c4f80-d724-11ea-8fe5-b11fec2a5c27.png)
+UPS Direct Credentials
 
-### Fetch Shipping Rates
-![core2](https://user-images.githubusercontent.com/17470909/89377460-70d4a500-d724-11ea-8550-a2813b936651.gif)
+Edit erpnext_shipping/erpnext_shipping/integrations/ups_direct.py
 
-You can see the list of shipping rates by clicking the `Fetch Shipping Rates` button. Once you picked a rate, it will create the shipment for you. 
+Populate your UPS Access Key, Username, and Password in the top-of-file configuration section.
 
-### Shipping Label
-![71bcfc9d-9d66-4a58-8238-1eeab4e9a24f 2020-08-05 09-48-32](https://user-images.githubusercontent.com/17470909/89377478-78944980-d724-11ea-8120-a5374c6e4c5e.png)
+Carrier Billing
 
-The service provider will also provide the shipping label and to generate the label, click on the `Print Shipping Label` on top of the doctype.
+FedEx (via EasyPost)
 
------------------------
-#### License
+Can use FedEx third-party billing: configure your FedEx account details under the EasyPost credentials.
 
-MIT
+UPS
+
+Third-party billing not available via EasyPost—must use the UPS direct connector above.
+
+User Contact
+
+Ensure the Pickup Contact Person on each Shipment has a first name, last name, email, and phone.
+
+📑 Usage
+Fetch Shipping Rates
+Open a Shipment (submitted, but not booked).
+
+Click Fetch Shipping Rates.
+
+Compare rates in the dialog (preferred services appear first).
+
+Click Buy to book that service and create the shipment.

--- a/erpnext_shipping/erpnext_shipping/doctype/easypost/easypost.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/easypost/easypost.py
@@ -1,9 +1,459 @@
 # Copyright (c) 2024, Frappe and contributors
 # For license information, please see license.txt
 
-# import frappe
-from frappe.model.document import Document
+import json
 
+import frappe
+import requests
+import re  # strips non-alphanumerics from account numbers
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import flt
+from frappe.utils.data import get_link_to_form
+from requests.exceptions import HTTPError
+from urllib.request import urlopen
+
+from erpnext_shipping.erpnext_shipping.utils import show_error_alert
+# UPS added imports
+from .ups_direct import UPSDirect, UPS_SHIPPER_NUM
+from requests.exceptions import HTTPError
+import base64, os, uuid
+from frappe.utils import get_files_path
+import io
+from PIL import Image
+
+EASYPOST_PROVIDER = "EasyPost"
 
 class EasyPost(Document):
-	pass
+    pass
+
+class EasyPostUtils():
+    def __init__(self):
+        settings = frappe.get_single("EasyPost")
+        self.api_key = settings.get_password("test_key")
+        self.enabled = settings.enabled
+        self.label_format = settings.label_format
+        self.currency = frappe.db.get_single_value("Shipping Settings", "rates_currency")
+
+        if not self.enabled:
+            link = get_link_to_form("EasyPost", "EasyPost", _("EasyPost Settings"))
+            frappe.throw(_("Please enable EasyPost Integration in {0}").format(link))
+
+    # ─────────────────────────────────────────────────────────────
+    # Human-friendly labels for the popup (does NOT affect API)
+    # ─────────────────────────────────────────────────────────────
+    _DISPLAY_MAP = {
+        # ---- Carrier aliases the rest of the code expects ----
+        "FEDEXDEFAULT": "FedEx",
+        "UPSDAP":       "UPS",
+        "USPS":         "USPS",
+        # Service renames (add / edit as you like)
+        "FEDEX_2_DAY":          "2-Day",
+        "FEDEX_EXPRESS_SAVER":  "Express Saver",
+        "FEDEX_GROUND":         "Ground",
+        "PRIORITY_OVERNIGHT":   "Priority Overnight",
+        "STANDARD_OVERNIGHT":   "Standard Overnight",
+        "GroundAdvantage":      "Ground Advantage",
+        "3DaySelect":           "3-Day",
+        "SMART_POST":           "Smart Post",
+        "2ndDayAir":            "2-Day",
+        "NextDayAirSaver":      "Next Day Air Saver",
+        "NextDayAir":           "Next Day Air",
+        "FEDEX_2_DAY_AM":       "2-Day AM",
+        "NextDayAirEarlyAM":    "Next Day Air AM",
+        "2ndDayAirAM":          "2-Day AM",
+    }
+
+    def _pretty(self, raw: str) -> str:
+        """Return nicer label if we have one."""
+        return self._DISPLAY_MAP.get(raw, raw)
+
+    def get_available_services(
+        self,
+        delivery_address,
+        delivery_contact,
+        shipment_parcel,
+        pickup_address,
+        pickup_contact,
+        value_of_goods
+    ):
+        if not self.enabled or not self.api_key:
+            return []
+
+        parcel = {
+            "length":  shipment_parcel[0]["length"],
+            "width":   shipment_parcel[0]["width"],
+            "height":  shipment_parcel[0]["height"],
+            "weight":  shipment_parcel[0]["weight"] * 16.0   # lb → oz
+        }
+
+        # ------------------------------------------------------------------
+        #  DEBUG + third-party extraction
+        # ------------------------------------------------------------------
+        third_party_block = {}
+
+        ship_doc = frappe.get_doc("Shipment", shipment_parcel[0]["parent"])
+        if not ship_doc:
+            frappe.throw(_("Could not locate parent Shipment for delivery address"))
+
+        bill_3p  = ship_doc.custom_ship_on_third_party
+        acct_3p  = ship_doc.custom_third_party_account
+        zip_3p   = ship_doc.custom_third_party_postal
+
+        clean_acct = None
+        if bill_3p:
+            if not (acct_3p and zip_3p):
+                frappe.throw(_("Please fill Customer Account # and Billing ZIP for third-party billing."))
+
+            clean_acct = re.sub(r"[^A-Za-z0-9]", "", acct_3p)
+            if len(clean_acct) == 0:
+                frappe.throw(_("Account number must contain at least one letter/number."))
+
+            third_party_block = {
+                "payment": {
+                    "type":        "THIRD_PARTY",
+                    "account":     clean_acct,
+                    "postal_code": zip_3p.strip(),
+                    "country":     "US"
+                }
+            }
+
+        shipment = {
+            'to_address': {
+                'name':    f"{delivery_contact.first_name} {delivery_contact.last_name}",
+                'street1': delivery_address.address_line1,
+                'street2': delivery_address.address_line2,
+                'city':    delivery_address.city,
+                'state':   delivery_address.state,
+                'zip':     delivery_address.pincode,
+                'country': delivery_address.country,
+                'phone':   delivery_contact.phone
+            },
+            'from_address': {
+                'name':    f"{pickup_contact.first_name} {pickup_contact.last_name}",
+                'street1': pickup_address.address_line1,
+                'street2': pickup_address.address_line2,
+                'city':    pickup_address.city,
+                'state':   pickup_address.state,
+                'zip':     pickup_address.pincode,
+                'country': pickup_address.country,
+                'phone':   pickup_contact.phone
+            },
+            'parcel': parcel,
+            'options': {
+                'currency': self.currency,
+                **third_party_block
+            }
+        }
+        #print(f"Shipment: {shipment}", flush=True)
+
+        if delivery_contact.email_id:
+            shipment['to_address']['email'] = delivery_contact.email_id
+        if pickup_contact.email_id:
+            shipment['from_address']['email'] = pickup_contact.email_id
+
+        try:
+            response = requests.post(
+                "https://api.easypost.com/v2/shipments",
+                json={"shipment": shipment},
+                auth=(self.api_key, "")
+            )
+            response_dict = response.json()
+
+            if "error" in response_dict:
+                error_message = response_dict["error"]["message"]
+                frappe.throw(error_message, title=_("EasyPost"))
+
+            available_services = []
+            for service in response_dict.get("rates", []):
+                available_service = self.get_service_dict(
+                    service,
+                    flt(shipment_parcel[0]['count']),
+                    response_dict.get("id")
+                )
+                available_services.append(available_service)
+
+            # ─────────────────────────────────────────────────────────────
+            # UPSDirect integration for third-party UPS billing
+            # ─────────────────────────────────────────────────────────────
+            if bill_3p:
+                ups = UPSDirect()
+                try:
+                    ups_rates = ups.rate(
+                        UPS_SHIPPER_NUM,
+                        clean_acct,
+                        zip_3p.strip(),
+                        shipment['to_address'],
+                        shipment['from_address'],
+                        parcel
+                    )
+                    
+                    rated_shipments = ups_rates.get('RateResponse', {}).get('RatedShipment', [])
+                   
+                    if isinstance(rated_shipments, dict):
+                        rated_shipments = [rated_shipments]
+                        
+                    for rated in rated_shipments:                    
+                        svc = rated["Service"]
+                        code = svc.get("Code") or ""
+                        # Prefer UPS-returned Description, but fall back to SERVICE_MAP or the raw code
+                        nice_name = svc.get("Description") or UPSDirect.SERVICE_MAP.get(code) or code
+
+                        available_services.append(frappe._dict({
+                            "service_provider": "UPS",
+                            "carrier":          "UPS",
+                            "service_name":      nice_name,  # ← friendly name now set
+                            "total_price":       flt(rated["TotalCharges"]["MonetaryValue"]),
+                            "delivery_days":     rated.get("GuaranteedDaysToDelivery"),
+                            "service_id":        code,
+                            "shipment_id":       None,
+                            "ups_shipper_number":UPS_SHIPPER_NUM,
+                            "ups_account":       clean_acct,
+                            "ups_postal_code":   zip_3p.strip(),
+                            "to_address":        shipment["to_address"],
+                            "from_address":      shipment["from_address"],
+                            "parcel":            parcel,
+                        }))
+
+                except HTTPError as e:
+                    print("UPS HTTPError:", getattr(e.response, "text", str(e)), flush=True)
+                    raise      # propagate the HTTP 4xx/5xx back to Frappe
+
+
+                except Exception as e:
+                    frappe.throw(_(f"Unexpected error creating UPS label: {str(e)}"))
+
+                    
+            # ─────────────────────────────────────────────────────────────
+            # If third-party billing, filter out all but UPS (6-digit acct)
+            # or FedEx (9-digit acct).
+            # ─────────────────────────────────────────────────────────────
+            if bill_3p:
+                if len(clean_acct) == 6:
+                    # only UPS rows
+                    available_services = [
+                        s for s in available_services
+                        if s.get("service_provider") == "UPS"
+                    ]
+                elif len(clean_acct) == 9:
+                    # only FedEx rows
+                    available_services = [
+                        s for s in available_services
+                        if s.get("carrier", "").lower() == "fedex"
+                    ]                    
+
+            return available_services
+
+        except Exception:
+            show_error_alert("fetching EasyPost prices")
+
+    def create_shipment(self, service_info, delivery_address):       
+        # ─────────────────────────────────────────────────────────────
+        # Custom UPS purchase flow
+        # ─────────────────────────────────────────────────────────────        
+        if isinstance(service_info, dict):
+            service_info = frappe._dict(service_info)
+         
+        if (service_info.get("service_provider") or "").upper() == "UPS":
+            ups = UPSDirect()
+            try:
+                resp = ups.ship(
+                    service_info.ups_shipper_number,
+                    service_info.ups_account,
+                    service_info.ups_postal_code,
+                    service_info.to_address,
+                    service_info.from_address,
+                    service_info.parcel,
+                    service_info.service_id
+                )
+
+                results = resp["ShipmentResponse"]["ShipmentResults"]
+
+                # ── normalise PackageResults to always be a list ────────────────
+                pkg_results = results.get("PackageResults", [])
+                if isinstance(pkg_results, dict):
+                    pkg_results = [pkg_results]
+
+                # tracking #
+                tracking = (
+                    results.get("ShipmentIdentificationNumber")
+                    or pkg_results[0].get("TrackingNumber")
+                )
+
+                # label block (may be missing if "LabelDelivery" = LabelLinkIndicator)
+                label_info = {}
+                if pkg_results:
+                    label_info = (
+                        pkg_results[0].get("LabelImage", {})          # newer docs
+                        or pkg_results[0].get("ShippingLabel", {})     # older docs
+                    )
+
+                graphic = label_info.get("GraphicImage")
+                fmt     = label_info.get("ImageFormat", {}).get("Code", "").lower()
+                label_url = f"data:image/{fmt};base64,{graphic}" if (graphic and fmt) else None
+
+
+                # ── save label data-URI → file so ERPNext can stream it
+                public_label_url = self._save_base64_png(label_url)
+                shipping_label   = public_label_url
+                #print(f"SHIPPING LABEL VARIABLE: {shipping_label}, flush=True)
+
+                return {
+                    "service_provider": "UPS",
+                    "shipment_id":      tracking,
+                    "carrier":          "UPS",
+                    "carrier_service":  service_info.service_name,
+                    "shipment_amount":  service_info.total_price,
+                    "awb_number":       tracking,
+
+                    # For ERPNext code paths that still expect this field
+                    "shipping_label":   shipping_label,
+
+                    # EasyPost-compatible block
+                    "postage_label": {
+                        "label_url":     public_label_url,
+                        "label_png_url": public_label_url,
+                        "label_pdf_url": public_label_url.replace(".png", ".pdf"),
+                    }
+                }            
+            except HTTPError as e:
+                print("UPS HTTPError:", getattr(e.response, "text", str(e)), flush=True)
+                raise      # propagate the HTTP 4xx/5xx back to Frappe
+
+        # ─────────────────────────────────────────────────────────────
+        # EasyPost purchase flow (unchanged)
+        # ─────────────────────────────────────────────────────────────
+        rate = {"rate": {"id": service_info['service_id']}}
+
+        if not self.enabled or not self.api_key:
+            return []
+
+        try:
+            response = requests.post(
+                f'https://api.easypost.com/v2/shipments/{service_info["shipment_id"]}/buy',
+                auth=(self.api_key, ""),
+                json=rate
+            )
+
+            response_data = response.json()
+            #print(response_data, flush=True)
+
+            if "error" in response_data:
+                frappe.throw(_("EasyPost Error: {0}").format(
+                    response_data["error"].get("message", "Unknown error")
+                ))
+
+            if 'failed_parcels' in response_data:
+                error = response_data['failed_parcels'][0]['errors']
+                frappe.msgprint(
+                    _('Error occurred while creating Shipment: {0}').format(error),
+                    indicator='orange', alert=True
+                )
+            else:
+                return {
+                    'service_provider': 'EasyPost',
+                    'shipment_id': service_info['shipment_id'],
+                    'carrier': self.get_carrier(service_info['carrier'], post_or_get="post"),
+                    'carrier_service': service_info['service_name'],
+                    'shipment_amount': service_info['total_price'],
+                    'awb_number': response_data['tracker']['tracking_code']
+                }
+
+        except Exception:
+            show_error_alert("creating EasyPost Shipment")
+
+    def get_label(self, shipment_id):
+        label_url = ""
+        key_format = "" if self.label_format == "png" else self.label_format + "_"
+
+        try:
+            shipment_label_response = requests.get(
+                f'https://api.easypost.com/v2/shipments/{shipment_id}/label?file_format={self.label_format}',
+                auth=(self.api_key, "")
+            )
+            shipment_label = shipment_label_response.json()
+            label_url = shipment_label['postage_label'][f'label_{key_format}url']
+
+            if label_url:
+                return label_url
+            else:
+                message = _(f"Please make sure Shipment (ID: {shipment_id}), exists and is a complete Shipment on EasyPost.")
+                frappe.msgprint(msg=_(message), title=_("Label Not Found"))
+        except Exception:
+            show_error_alert("printing EasyPost Label")
+
+    def get_tracking_data(self, shipment_id):
+        try:
+            tracking_data_response = requests.get(
+                f'https://api.easypost.com/v2/shipments/{shipment_id}',
+                auth=(self.api_key, "")
+            )
+            tracking_data = json.loads(tracking_data_response.text)
+            tracking_data_parcel = tracking_data['tracker']
+
+            return {
+                'awb_number': tracking_data_parcel['tracking_code'],
+                'tracking_status': tracking_data_parcel['status'],
+                'tracking_status_info': tracking_data_parcel['status_detail'],
+                'tracking_url': tracking_data_parcel['public_url']
+            }
+        except Exception:
+            show_error_alert("updating EasyPost Shipment")
+
+    def get_service_dict(self, service, parcel_count, shipment_id):
+        available_service = frappe._dict()
+        available_service.service_provider = 'EasyPost'
+        raw_carrier = self.get_carrier(service['carrier'], post_or_get="get")
+        available_service.carrier = self._pretty(raw_carrier)
+        raw_service = service['service']
+        available_service.service_name = self._pretty(raw_service)
+        available_service.total_price = flt(service['rate']) * parcel_count
+        available_service.delivery_days = service.get('delivery_days')
+        available_service.service_id = service['id']
+        available_service.shipment_id = shipment_id
+        return available_service
+
+    def get_carrier(self, carrier_name, post_or_get=None):
+        if carrier_name in ("easypost", "EasyPost"):
+            return "EasyPost" if post_or_get == "get" else "easypost"
+        else:
+            return carrier_name.upper() if post_or_get == "get" else carrier_name.lower()
+    
+    def _save_base64_png(self, data_uri: str) -> str:
+        """
+        Decode a data-URI, rotate it 90° clockwise, save as a *private* File,
+        create the matching File Doc, and return the absolute URL.
+        """
+        if not data_uri or not data_uri.startswith("data:image"):
+            return data_uri                     # already a URL – nothing to do
+
+        header, b64 = data_uri.split(",", 1)
+        ext   = header.split("/")[1].split(";")[0]          # "png", "gif", …
+
+        # ── decode base-64 → bytes ───────────────────────────────────────
+        raw_bytes = base64.b64decode(b64)
+
+        # ▲ ROTATE the image upright with Pillow
+        img = Image.open(io.BytesIO(raw_bytes))
+        img = img.rotate(-90, expand=True)                  # -90 = 90° clockwise
+
+        # save the rotated image to disk
+        fname = f"{uuid.uuid4()}.{ext}"
+        file_path = os.path.join(get_files_path(is_private=True), fname)
+        img.save(file_path, format=ext.upper())
+
+        # ── register a File doc so /private/files/* isn’t “Forbidden” ────
+        file_doc = frappe.get_doc({
+            "doctype":   "File",
+            "file_name": fname,
+            "file_url":  f"/private/files/{fname}",
+            "is_private": 1,
+        })
+        file_doc.insert(ignore_permissions=True)
+
+        return f"{frappe.utils.get_url()}{file_doc.file_url}"
+
+
+    def test(self):
+        frappe.msg("gello")
+

--- a/erpnext_shipping/erpnext_shipping/doctype/easypost/easypost.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/easypost/easypost.py
@@ -1,33 +1,56 @@
 # Copyright (c) 2024, Frappe and contributors
 # For license information, please see license.txt
-
+#frappe.log_error(title="Bill_3p 2", message=f"bill_3p: {bill_3p}, clean_acct: {acct_3p}")
 import json
+import base64
+import io
+import os
+import re                # strips non‑alphanumerics from account numbers
+import uuid
+import time
+from typing import List, Dict, Any
 
 import frappe
 import requests
-import re  # strips non-alphanumerics from account numbers
+from PIL import Image
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import flt
-from frappe.utils.data import get_link_to_form
+from frappe.utils import flt, get_link_to_form, get_url, get_files_path
 from requests.exceptions import HTTPError
-from urllib.request import urlopen
 
 from erpnext_shipping.erpnext_shipping.utils import show_error_alert
-# UPS added imports
+
+# UPS‑Direct imports -----------------------------------------------------------
 from .ups_direct import UPSDirect, UPS_SHIPPER_NUM
-from requests.exceptions import HTTPError
-import base64, os, uuid
-from frappe.utils import get_files_path
-import io
-from PIL import Image
 
 EASYPOST_PROVIDER = "EasyPost"
+
+# ─────────────────────────────────────────────
+# Helper: turn each row into N identical parcel dicts
+# ─────────────────────────────────────────────
+def build_parcel_list(rows):
+    """
+    Return a flat list with ONE element per physical box.
+    Each element is a dict shaped exactly like EasyPost's Parcel.
+    """
+    parcels = []
+    for row in rows:
+        qty = int(row.get("count") or 1)
+        parcel = {
+            "length":  row["length"],
+            "width":   row["width"],
+            "height":  row["height"],
+            "weight":  row["weight"] * 16.0,  # EasyPost wants ounces
+        }
+        parcels.extend([parcel] * qty)
+    return parcels
+
 
 class EasyPost(Document):
     pass
 
-class EasyPostUtils():
+
+class EasyPostUtils:
     def __init__(self):
         settings = frappe.get_single("EasyPost")
         self.api_key = settings.get_password("test_key")
@@ -39,56 +62,65 @@ class EasyPostUtils():
             link = get_link_to_form("EasyPost", "EasyPost", _("EasyPost Settings"))
             frappe.throw(_("Please enable EasyPost Integration in {0}").format(link))
 
-    # ─────────────────────────────────────────────────────────────
-    # Human-friendly labels for the popup (does NOT affect API)
-    # ─────────────────────────────────────────────────────────────
+    # ──────────────────────────────────────────────────────────────────────
+    # Human‑friendly labels for the popup (does NOT affect the API)
+    # ──────────────────────────────────────────────────────────────────────
     _DISPLAY_MAP = {
         # ---- Carrier aliases the rest of the code expects ----
         "FEDEXDEFAULT": "FedEx",
         "UPSDAP":       "UPS",
         "USPS":         "USPS",
-        # Service renames (add / edit as you like)
-        "FEDEX_2_DAY":          "2-Day",
+        # ---- Service renames (add / edit as you like) ----
+        "FEDEX_2_DAY":          "2‑Day",
         "FEDEX_EXPRESS_SAVER":  "Express Saver",
         "FEDEX_GROUND":         "Ground",
         "PRIORITY_OVERNIGHT":   "Priority Overnight",
         "STANDARD_OVERNIGHT":   "Standard Overnight",
         "GroundAdvantage":      "Ground Advantage",
-        "3DaySelect":           "3-Day",
+        "3DaySelect":           "3‑Day",
         "SMART_POST":           "Smart Post",
-        "2ndDayAir":            "2-Day",
+        "2ndDayAir":            "2‑Day",
         "NextDayAirSaver":      "Next Day Air Saver",
         "NextDayAir":           "Next Day Air",
-        "FEDEX_2_DAY_AM":       "2-Day AM",
-        "NextDayAirEarlyAM":    "Next Day Air AM",
-        "2ndDayAirAM":          "2-Day AM",
+        "FEDEX_2_DAY_AM":       "2‑Day AM",
+        "NextDayAirEarlyAM":    "Next Day Air AM",
+        "2ndDayAirAM":          "2‑Day AM",
+        "UPSGroundsaverGreaterThan1lb": "Ground Saver",
+        "FIRST_OVERNIGHT": "Next Day Air AM",   
     }
 
     def _pretty(self, raw: str) -> str:
         """Return nicer label if we have one."""
         return self._DISPLAY_MAP.get(raw, raw)
 
-    def get_available_services(
-        self,
-        delivery_address,
-        delivery_contact,
-        shipment_parcel,
-        pickup_address,
-        pickup_contact,
-        value_of_goods
-    ):
+    def _rate_in_all_shipments(self, rate_obj, shipments) -> bool:
+        """True iff every shipment has a rate with the same carrier+service."""
+        c = rate_obj["carrier"]
+        s = rate_obj["service"]
+        for sh in shipments:
+            if not any(r["carrier"] == c and r["service"] == s for r in sh.get("rates", [])):
+                return False
+        return True
+
+    # =========================================================================
+    # MAIN RATE‑SHOPPING ENDPOINT
+    # =========================================================================
+    def get_available_services(self, delivery_address, delivery_contact, shipment_parcel: List[Dict[str, Any]], pickup_address, pickup_contact, value_of_goods, ) -> List[Dict[str, Any]]:
         if not self.enabled or not self.api_key:
             return []
 
-        parcel = {
-            "length":  shipment_parcel[0]["length"],
-            "width":   shipment_parcel[0]["width"],
-            "height":  shipment_parcel[0]["height"],
-            "weight":  shipment_parcel[0]["weight"] * 16.0   # lb → oz
-        }
+        parcels = build_parcel_list(shipment_parcel)
+        if not parcels:
+            frappe.throw(_("No parcel data supplied to EasyPost."))
+        parcel_count = len(parcels)
+        first_parcel = parcels[0]
+        mps = parcel_count > 1        # multi-piece shipment?
+
+        parcel_block = ({"parcel": first_parcel} # 1 box only
+        if parcel_count == 1 else {"parcels": parcels}) # 2+ boxes
 
         # ------------------------------------------------------------------
-        #  DEBUG + third-party extraction
+        # Third‑party billing extraction for UPS
         # ------------------------------------------------------------------
         third_party_block = {}
 
@@ -96,16 +128,18 @@ class EasyPostUtils():
         if not ship_doc:
             frappe.throw(_("Could not locate parent Shipment for delivery address"))
 
-        bill_3p  = ship_doc.custom_ship_on_third_party
+        bill_3p = (
+            ship_doc.get("custom_ship_on_third_party") in (1, "1", True, "Yes")
+            and bool(ship_doc.get("custom_third_party_account"))
+        )
         acct_3p  = ship_doc.custom_third_party_account
+        clean_acct = re.sub(r"[^A-Za-z0-9]", "", acct_3p)
         zip_3p   = ship_doc.custom_third_party_postal
-
-        clean_acct = None
-        if bill_3p:
+        
+        if bill_3p and len(clean_acct) == 6:          
             if not (acct_3p and zip_3p):
-                frappe.throw(_("Please fill Customer Account # and Billing ZIP for third-party billing."))
+                frappe.throw(_("Please fill Customer Account # and Billing ZIP for third‑party billing."))
 
-            clean_acct = re.sub(r"[^A-Za-z0-9]", "", acct_3p)
             if len(clean_acct) == 0:
                 frappe.throw(_("Account number must contain at least one letter/number."))
 
@@ -114,146 +148,230 @@ class EasyPostUtils():
                     "type":        "THIRD_PARTY",
                     "account":     clean_acct,
                     "postal_code": zip_3p.strip(),
-                    "country":     "US"
+                    "country":     "US",
                 }
             }
 
-        shipment = {
-            'to_address': {
-                'name':    f"{delivery_contact.first_name} {delivery_contact.last_name}",
-                'street1': delivery_address.address_line1,
-                'street2': delivery_address.address_line2,
-                'city':    delivery_address.city,
-                'state':   delivery_address.state,
-                'zip':     delivery_address.pincode,
-                'country': delivery_address.country,
-                'phone':   delivery_contact.phone
+        # ------------------------------------------------------------------
+        # Compose EasyPost shipment payload
+        # ------------------------------------------------------------------
+        shipment: Dict[str, Any] = {
+            "to_address": {
+                "name":    f"{delivery_contact.first_name} {delivery_contact.last_name}",
+                "street1": delivery_address.address_line1,
+                "street2": delivery_address.address_line2,
+                "city":    delivery_address.city,
+                "state":   delivery_address.state,
+                "zip":     delivery_address.pincode,
+                "country": delivery_address.country,
+                "phone":   delivery_contact.phone,
             },
-            'from_address': {
-                'name':    f"{pickup_contact.first_name} {pickup_contact.last_name}",
-                'street1': pickup_address.address_line1,
-                'street2': pickup_address.address_line2,
-                'city':    pickup_address.city,
-                'state':   pickup_address.state,
-                'zip':     pickup_address.pincode,
-                'country': pickup_address.country,
-                'phone':   pickup_contact.phone
+            "from_address": {
+                "name":    f"{pickup_contact.first_name} {pickup_contact.last_name}",
+                "street1": pickup_address.address_line1,
+                "street2": pickup_address.address_line2,
+                "city":    pickup_address.city,
+                "state":   pickup_address.state,
+                "zip":     pickup_address.pincode,
+                "country": pickup_address.country,
+                "phone":   pickup_contact.phone,
             },
-            'parcel': parcel,
-            'options': {
-                'currency': self.currency,
-                **third_party_block
-            }
+            **parcel_block,           # ← single or multi‑piece
+            "options": {
+                "currency": self.currency,
+                **third_party_block,
+            },
         }
-        #print(f"Shipment: {shipment}", flush=True)
 
         if delivery_contact.email_id:
-            shipment['to_address']['email'] = delivery_contact.email_id
+            shipment["to_address"]["email"] = delivery_contact.email_id
         if pickup_contact.email_id:
-            shipment['from_address']['email'] = pickup_contact.email_id
+            shipment["from_address"]["email"] = pickup_contact.email_id
 
         try:
-            response = requests.post(
-                "https://api.easypost.com/v2/shipments",
-                json={"shipment": shipment},
-                auth=(self.api_key, "")
-            )
+            if not mps:
+                ep_url = "https://api.easypost.com/v2/shipments"
+                payload = {"shipment": shipment}
+            else:
+                # ── build an Order with one Shipment per parcel ──
+                ep_url = "https://api.easypost.com/v2/orders"
+                payload = {
+                    "order": {
+                        "to_address":   shipment["to_address"],
+                        "from_address": shipment["from_address"],
+                        "shipments": [
+                            {"parcel": p, "options": shipment["options"]} for p in parcels
+                        ],
+                    }
+                }
+            #frappe.log_error(title="ep_url", message=f"{ep_url}")
+            response = requests.post(ep_url, auth=(self.api_key, ""), json=payload)
             response_dict = response.json()
 
+            # ---- Handle EasyPost API errors --------------------------------
             if "error" in response_dict:
-                error_message = response_dict["error"]["message"]
-                frappe.throw(error_message, title=_("EasyPost"))
+                frappe.throw(response_dict["error"]["message"], title=_("EasyPost"))
 
-            available_services = []
+            available_services: List[Dict[str, Any]] = []
             for service in response_dict.get("rates", []):
                 available_service = self.get_service_dict(
                     service,
-                    flt(shipment_parcel[0]['count']),
-                    response_dict.get("id")
+                    1 if mps else parcel_count,    # Order returns full price already
+                    response_dict.get("id"),
+                    is_order=mps
                 )
                 available_services.append(available_service)
 
             # ─────────────────────────────────────────────────────────────
-            # UPSDirect integration for third-party UPS billing
+            # UPSDirect integration for third‑party UPS billing (single‑parcel)
             # ─────────────────────────────────────────────────────────────
             if bill_3p:
+                #frappe.log_error(title="Bill_3p single", message=f"bill_3p: {bill_3p}, clean_acct: {acct_3p}")
                 ups = UPSDirect()
                 try:
                     ups_rates = ups.rate(
                         UPS_SHIPPER_NUM,
                         clean_acct,
                         zip_3p.strip(),
-                        shipment['to_address'],
-                        shipment['from_address'],
-                        parcel
+                        shipment["to_address"],
+                        shipment["from_address"],
+                        parcels
                     )
-                    
-                    rated_shipments = ups_rates.get('RateResponse', {}).get('RatedShipment', [])
-                   
+
+                    rated_shipments = ups_rates.get("RateResponse", {}).get("RatedShipment", [])
                     if isinstance(rated_shipments, dict):
                         rated_shipments = [rated_shipments]
-                        
-                    for rated in rated_shipments:                    
+
+                    for rated in rated_shipments:
                         svc = rated["Service"]
                         code = svc.get("Code") or ""
-                        # Prefer UPS-returned Description, but fall back to SERVICE_MAP or the raw code
-                        nice_name = svc.get("Description") or UPSDirect.SERVICE_MAP.get(code) or code
+                        nice_name = (
+                            svc.get("Description")
+                            or UPSDirect.SERVICE_MAP.get(code)
+                            or code
+                        )
 
-                        available_services.append(frappe._dict({
-                            "service_provider": "UPS",
-                            "carrier":          "UPS",
-                            "service_name":      nice_name,  # ← friendly name now set
-                            "total_price":       flt(rated["TotalCharges"]["MonetaryValue"]),
-                            "delivery_days":     rated.get("GuaranteedDaysToDelivery"),
-                            "service_id":        code,
-                            "shipment_id":       None,
-                            "ups_shipper_number":UPS_SHIPPER_NUM,
-                            "ups_account":       clean_acct,
-                            "ups_postal_code":   zip_3p.strip(),
-                            "to_address":        shipment["to_address"],
-                            "from_address":      shipment["from_address"],
-                            "parcel":            parcel,
-                        }))
+                        available_services.append(
+                            frappe._dict({
+                                "service_provider": "UPS",
+                                "carrier":          "UPS",
+                                "service_name":     nice_name,
+                                "total_price":      flt(rated["TotalCharges"]["MonetaryValue"]),
+                                "delivery_days":    rated.get("GuaranteedDaysToDelivery"),
+                                "service_id":       code,
+                                "shipment_id":      None,
+                                "ups_shipper_number": UPS_SHIPPER_NUM,
+                                "ups_account":        clean_acct,
+                                "ups_postal_code":    zip_3p.strip(),
+                                "to_address":         shipment["to_address"],
+                                "from_address":       shipment["from_address"],
+                                "parcels":             parcels,
+                            })
+                        )
 
                 except HTTPError as e:
                     print("UPS HTTPError:", getattr(e.response, "text", str(e)), flush=True)
-                    raise      # propagate the HTTP 4xx/5xx back to Frappe
-
-
+                    raise  # propagate the HTTP 4xx/5xx back to Frappe
                 except Exception as e:
                     frappe.throw(_(f"Unexpected error creating UPS label: {str(e)}"))
 
-                    
-            # ─────────────────────────────────────────────────────────────
-            # If third-party billing, filter out all but UPS (6-digit acct)
-            # or FedEx (9-digit acct).
-            # ─────────────────────────────────────────────────────────────
+            # ---- Filter by carrier for 3‑P billing -------------------------
             if bill_3p:
-                if len(clean_acct) == 6:
-                    # only UPS rows
-                    available_services = [
-                        s for s in available_services
-                        if s.get("service_provider") == "UPS"
-                    ]
-                elif len(clean_acct) == 9:
-                    # only FedEx rows
-                    available_services = [
-                        s for s in available_services
-                        if s.get("carrier", "").lower() == "fedex"
-                    ]                    
+                if len(clean_acct) == 6:      # UPS (6‑digit acct)
+                    available_services = [s for s in available_services if s.get("service_provider") == "UPS"]
+                elif len(clean_acct) == 9:    # FedEx (9‑digit acct)
+                    available_services = [s for s in available_services if s.get("carrier", "").lower() == "fedex"]
 
+            # FedEx-selector by parcel-count (easypost fedex account does not support multiple parcels)
+            if parcel_count > 1:
+                # multi-parcel → keep *our* FedEx account (“FEDEX”), drop EasyPost’s pooled account (“FEDEXDEFAULT”)
+                available_services = [
+                    s for s in available_services
+                    if (s.get("carrier_code") or "").upper() != "FEDEXDEFAULT"
+                ]
+            else:
+                # single-parcel → keep EasyPost’s “FEDEXDEFAULT”, drop *our* “FEDEX”
+                available_services = [
+                    s for s in available_services
+                    if (s.get("carrier_code") or "").upper() != "FEDEX"
+                ]
+    
             return available_services
 
         except Exception:
             show_error_alert("fetching EasyPost prices")
 
-    def create_shipment(self, service_info, delivery_address):       
-        # ─────────────────────────────────────────────────────────────
+    # =========================================================================
+    # PURCHASE LABELS (EasyPost or UPSDirect)
+    # =========================================================================
+    def create_shipment(self, service_info, delivery_address):
+        # ─────────────────────────────────────────────────────────────────
         # Custom UPS purchase flow
-        # ─────────────────────────────────────────────────────────────        
+        # ─────────────────────────────────────────────────────────────────
         if isinstance(service_info, dict):
             service_info = frappe._dict(service_info)
-         
+            
+        # ───────────────────────────
+        # EasyPost ORDER (multi-parcel) - Requires the "orders" api endpoint
+        # ───────────────────────────
+        if service_info.get("is_order"):
+            buy_body = {
+                "carrier": service_info.carrier_code,   # "FedExDefault", "UPSDAP", etc.
+                "service": service_info.service_code    # "FEDEX_GROUND", "Ground", ...
+            }
+            
+            rate_check = requests.get(
+                f"https://api.easypost.com/v2/orders/{service_info['order_id']}",
+                auth=(self.api_key, ""),
+            ).json()
+            #frappe.log_error("EZP Order detail", json.dumps(rate_check)[:200000])
+            
+            resp = requests.post(
+                f"https://api.easypost.com/v2/orders/{service_info['order_id']}/buy",
+                auth=(self.api_key, ""),
+                json=buy_body,
+            ).json()
+
+            # Handle explicit EasyPost error objects
+            if "error" in resp:
+                frappe.throw(_("EasyPost Error: {0}").format(resp["error"].get("message")))
+
+            # Different API revisions: 'shipments' is sometimes nested
+            shipments = (
+                resp.get("shipments") or
+                resp.get("order", {}).get("shipments") or
+                []
+            )
+
+            if not shipments:
+                frappe.throw(_("EasyPost returned no shipments for this order."))
+
+            # collect tracking & labels
+            labels   = [s["postage_label"]["label_url"] for s in shipments]
+            tracknos = [s["tracking_code"]              for s in shipments]
+
+            first_label = labels[0]
+            merged_pdf_url = self._pngs_to_pdf(labels)
+            postage_stub = {"label_url": first_label, "label_png_url": first_label, "label_pdf_url": first_label.replace(".png", ".pdf")}
+
+            return {
+                "service_provider": "EasyPost",
+                "order_id":  service_info["order_id"],
+                "shipment_id":     service_info["order_id"],
+                "carrier":   self.get_carrier(service_info["carrier"], post_or_get="post"),
+                "carrier_service": service_info["service_name"],
+                "shipment_amount": service_info["total_price"],
+                "awb_number": ", ".join(tracknos),
+                "label_bundle": labels,   # raw PNGs if you need them
+                "shipping_label": merged_pdf_url,
+                "postage_label":  postage_stub,
+                "awb_number":      ", ".join(tracknos),
+            }
+
+
+        # ───────────────────────────
+        # UPS 3rd Party Billing ORDER (multiple & single parcel)
+        # ───────────────────────────
         if (service_info.get("service_provider") or "").upper() == "UPS":
             ups = UPSDirect()
             try:
@@ -263,67 +381,76 @@ class EasyPostUtils():
                     service_info.ups_postal_code,
                     service_info.to_address,
                     service_info.from_address,
-                    service_info.parcel,
-                    service_info.service_id
+                    service_info.parcels,
+                    service_info.service_id,
                 )
 
                 results = resp["ShipmentResponse"]["ShipmentResults"]
 
-                # ── normalise PackageResults to always be a list ────────────────
+                # ---------- collect every package's tracking + label ----------
                 pkg_results = results.get("PackageResults", [])
-                if isinstance(pkg_results, dict):
+                if isinstance(pkg_results, dict):          # UPS returns dict when just 1 pkg
                     pkg_results = [pkg_results]
 
-                # tracking #
-                tracking = (
-                    results.get("ShipmentIdentificationNumber")
-                    or pkg_results[0].get("TrackingNumber")
+                tracking_numbers = []
+                png_urls = []
+
+                for pr in pkg_results:
+                    tracking_numbers.append(pr.get("TrackingNumber"))
+
+                    lbl = pr.get("LabelImage") or pr.get("ShippingLabel", {})
+                    graphic = lbl.get("GraphicImage")
+                    fmt = (lbl.get("ImageFormat") or {}).get("Code", "").lower()
+
+                    if graphic and fmt:
+                        data_uri = f"data:image/{fmt};base64,{graphic}"
+                        png_urls.append(self._save_base64_png(data_uri))
+
+                if not png_urls:
+                    frappe.throw(_("UPS did not return any label images."))
+
+                # ---------- convert every PNG ➜ single PDF ----------
+                pdf_url = (
+                    self._png_to_pdf(png_urls[0])          # 1 parcel
+                    if len(png_urls) == 1
+                    else self._pngs_to_pdf(png_urls)       # 2+ parcels
                 )
-
-                # label block (may be missing if "LabelDelivery" = LabelLinkIndicator)
-                label_info = {}
-                if pkg_results:
-                    label_info = (
-                        pkg_results[0].get("LabelImage", {})          # newer docs
-                        or pkg_results[0].get("ShippingLabel", {})     # older docs
-                    )
-
-                graphic = label_info.get("GraphicImage")
-                fmt     = label_info.get("ImageFormat", {}).get("Code", "").lower()
-                label_url = f"data:image/{fmt};base64,{graphic}" if (graphic and fmt) else None
-
-
-                # ── save label data-URI → file so ERPNext can stream it
-                public_label_url = self._save_base64_png(label_url)
-                shipping_label   = public_label_url
-                #print(f"SHIPPING LABEL VARIABLE: {shipping_label}, flush=True)
 
                 return {
                     "service_provider": "UPS",
-                    "shipment_id":      tracking,
+                    "shipment_id":      tracking_numbers[0],
                     "carrier":          "UPS",
                     "carrier_service":  service_info.service_name,
                     "shipment_amount":  service_info.total_price,
-                    "awb_number":       tracking,
-
-                    # For ERPNext code paths that still expect this field
-                    "shipping_label":   shipping_label,
-
-                    # EasyPost-compatible block
+                    "awb_number":       ", ".join(tracking_numbers),
+                    "label_bundle":     png_urls,      # raw PNGs if you need them
+                    "shipping_label":   pdf_url,       # one multi-page PDF
                     "postage_label": {
-                        "label_url":     public_label_url,
-                        "label_png_url": public_label_url,
-                        "label_pdf_url": public_label_url.replace(".png", ".pdf"),
-                    }
-                }            
+                        "label_url":     pdf_url,
+                        "label_png_url": png_urls[0],  # first page preview
+                        "label_pdf_url": pdf_url,
+                    },
+                }
             except HTTPError as e:
-                print("UPS HTTPError:", getattr(e.response, "text", str(e)), flush=True)
-                raise      # propagate the HTTP 4xx/5xx back to Frappe
+                # pull the JSON explanation if UPS sent one
+                try:
+                    err_json = e.response.json()
+                    detail = (
+                        err_json.get("response", {})
+                                .get("errors", [{}])[0]
+                                .get("message")
+                        or err_json
+                    )
+                except Exception:
+                    detail = e.response.text or str(e)
 
-        # ─────────────────────────────────────────────────────────────
-        # EasyPost purchase flow (unchanged)
-        # ─────────────────────────────────────────────────────────────
-        rate = {"rate": {"id": service_info['service_id']}}
+                frappe.throw(_("UPS API Error: {0}").format(detail))
+
+
+        # ───────────────────────────
+        # EasyPost ORDER (single-parcel) - Requires the "shipments" api endpoint
+        # ───────────────────────────
+        rate = {"rate": {"id": service_info["service_id"]}}
 
         if not self.enabled or not self.api_key:
             return []
@@ -332,117 +459,214 @@ class EasyPostUtils():
             response = requests.post(
                 f'https://api.easypost.com/v2/shipments/{service_info["shipment_id"]}/buy',
                 auth=(self.api_key, ""),
-                json=rate
+                json=rate,
             )
 
             response_data = response.json()
-            #print(response_data, flush=True)
-
             if "error" in response_data:
-                frappe.throw(_("EasyPost Error: {0}").format(
-                    response_data["error"].get("message", "Unknown error")
-                ))
+                frappe.throw(_("EasyPost Error: {0}").format(response_data["error"].get("message", "Unknown error")))
 
-            if 'failed_parcels' in response_data:
-                error = response_data['failed_parcels'][0]['errors']
-                frappe.msgprint(
-                    _('Error occurred while creating Shipment: {0}').format(error),
-                    indicator='orange', alert=True
-                )
+            if "failed_parcels" in response_data:
+                error = response_data["failed_parcels"][0]["errors"]
+                frappe.msgprint(_(f"Error occurred while creating Shipment: {error}"), indicator="orange", alert=True)
             else:
-                return {
-                    'service_provider': 'EasyPost',
-                    'shipment_id': service_info['shipment_id'],
-                    'carrier': self.get_carrier(service_info['carrier'], post_or_get="post"),
-                    'carrier_service': service_info['service_name'],
-                    'shipment_amount': service_info['total_price'],
-                    'awb_number': response_data['tracker']['tracking_code']
+                                # ------------------------------------------------------------------
+                # 1 We have a PAID EasyPost Shipment – grab the PNG label
+                # ------------------------------------------------------------------
+                lbl_resp = requests.get(
+                    f"https://api.easypost.com/v2/shipments/{service_info['shipment_id']}/label",
+                    auth=(self.api_key, ""),
+                    params={"file_format": "png"},
+                ).json()
+
+                png_url = lbl_resp["postage_label"]["label_url"]
+
+                # 2 Convert that single PNG → single-page PDF, save to File
+                pdf_url = self._pngs_to_pdf([png_url]) 
+
+                # 3 Normalise the postage-label stub (helpful for API users)
+                postage_stub = {
+                    "label_url":     pdf_url,      # the PDF we just stored
+                    "label_png_url": png_url,      # raw PNG (preview)
+                    "label_pdf_url": pdf_url,
                 }
 
+                # 4 Return exactly like the multi-parcel path
+                return {
+                    "service_provider": "EasyPost",
+                    "shipment_id": service_info["shipment_id"],
+                    "carrier": self.get_carrier(service_info["carrier"], post_or_get="post"),
+                    "carrier_service": service_info["service_name"],
+                    "shipment_amount": service_info["total_price"],
+                    "awb_number": response_data["tracker"]["tracking_code"],
+                    "label_bundle":     [png_url],      # keep parity with Orders
+                    "shipping_label":   pdf_url,        # what ERPNext will open
+                    "postage_label":    postage_stub,
+                }
         except Exception:
             show_error_alert("creating EasyPost Shipment")
 
     def get_label(self, shipment_id):
-        label_url = ""
-        key_format = "" if self.label_format == "png" else self.label_format + "_"
+        """
+        Return a printable label URL.
 
+        • Multi-parcel Order: ask EasyPost for ONE PNG that contains a page per
+          parcel. Poll up to ~6 s; fall back to the first parcel’s PNG.
+        • Single-parcel Shipment: unchanged.
+        """
         try:
-            shipment_label_response = requests.get(
-                f'https://api.easypost.com/v2/shipments/{shipment_id}/label?file_format={self.label_format}',
-                auth=(self.api_key, "")
-            )
-            shipment_label = shipment_label_response.json()
-            label_url = shipment_label['postage_label'][f'label_{key_format}url']
+            # ── Multi-parcel Order ───────────────────────────────────────────
+            if shipment_id.startswith("order_"):
 
-            if label_url:
-                return label_url
-            else:
-                message = _(f"Please make sure Shipment (ID: {shipment_id}), exists and is a complete Shipment on EasyPost.")
-                frappe.msgprint(msg=_(message), title=_("Label Not Found"))
+                #requests.post(
+                #    f"https://api.easypost.com/v2/orders/{shipment_id}/label",
+                #    auth=(self.api_key, ""),
+                #    json={"file_format": "PNG"},
+                #    timeout=20,
+                #)
+
+                # always fetch the fresh Order object
+                order = requests.get(
+                    f"https://api.easypost.com/v2/orders/{shipment_id}",
+                    auth=(self.api_key, ""),
+                    timeout=20,
+                ).json()
+
+                # collect every individual PNG
+                label_urls = [
+                    s.get("postage_label", {}).get("label_url")
+                    for s in order.get("shipments", [])
+                    if s.get("postage_label")
+                ]
+                label_urls = [u for u in label_urls if u]
+
+                if not label_urls:
+                    frappe.throw(_("EasyPost did not return any label URLs for this Order."))
+
+                # single box? just return it
+                if len(label_urls) == 1:
+                    return label_urls[0]
+
+                # 2+ boxes → stitch them
+                return self._pngs_to_pdf(label_urls)
+
+                frappe.throw(_("EasyPost did not return any label URLs for this Order."))
+
+            # ── Single-parcel Shipment → always return a local PDF ─────────
+
+            # 1️⃣  Ask EasyPost for the PNG (never mind self.label_format)
+            shp = requests.get(
+                f"https://api.easypost.com/v2/shipments/{shipment_id}/label",
+                auth=(self.api_key, ""),
+                params={"file_format": "png"},
+            ).json()
+
+            png_url = shp["postage_label"]["label_url"]
+
+            # 2️⃣  Convert PNG → PDF  (re-runs instantly if we’ve done it before)
+            pdf_url = self._png_to_pdf(png_url)
+
+            # 3️⃣  OPTIONAL: write back to the Shipment doctype so future
+            #     clicks skip the network hop completely.
+            try:
+                doc = frappe.get_doc("Shipment", {"easy_post_shipment_id": shipment_id})
+                if doc and (doc.get("shipping_label") != pdf_url):
+                    doc.db_set("shipping_label", pdf_url, update_modified=False)
+            except Exception:
+                # ignore if mapping field doesn’t exist or any other issue
+                pass
+
+            return pdf_url
+
+
         except Exception:
             show_error_alert("printing EasyPost Label")
 
-    def get_tracking_data(self, shipment_id):
-        try:
-            tracking_data_response = requests.get(
-                f'https://api.easypost.com/v2/shipments/{shipment_id}',
-                auth=(self.api_key, "")
-            )
-            tracking_data = json.loads(tracking_data_response.text)
-            tracking_data_parcel = tracking_data['tracker']
 
+
+    def get_tracking_data(self, ep_id: str):
+        """Return tracking data for a single-parcel **or** multi-parcel shipment."""
+        try:
+            if ep_id.startswith("order_"):                         # <-- NEW
+                r = requests.get(f"https://api.easypost.com/v2/orders/{ep_id}",
+                                  auth=(self.api_key, "")).json()
+                
+                chosen_carrier = (r.get("selected_rate") or {}).get("carrier", "").upper()
+                msgs = [
+                    m["message"]
+                    for m in r.get("messages", [])
+                    if (m.get("carrier", "") or "").upper() == chosen_carrier
+                ]
+                             
+                # collect trackers from every parcel in the order
+                tracking_codes = [
+                    (sh.get("tracker") or {}).get("tracking_code") or sh.get("tracking_code")
+                    for sh in r.get("shipments", [])
+                ]
+
+                return {
+                    "awb_number": ", ".join(filter(None, tracking_codes)),
+                    "tracking_status": r.get("status"),
+                    "tracking_status_info": " / ".join(msgs) if msgs else None,
+                    "tracking_url": f"https://track.easypost.com/{tracking_codes[0]}"
+                                     if tracking_codes else None
+                }
+
+            # ---------- existing single-parcel logic ----------
+            r = requests.get(f"https://api.easypost.com/v2/shipments/{ep_id}",
+                             auth=(self.api_key, "")).json()
+            t = r["tracker"]
             return {
-                'awb_number': tracking_data_parcel['tracking_code'],
-                'tracking_status': tracking_data_parcel['status'],
-                'tracking_status_info': tracking_data_parcel['status_detail'],
-                'tracking_url': tracking_data_parcel['public_url']
+                "awb_number": t["tracking_code"],
+                "tracking_status": t["status"],
+                "tracking_status_info": t["status_detail"],
+                "tracking_url": t["public_url"],
             }
         except Exception:
             show_error_alert("updating EasyPost Shipment")
 
-    def get_service_dict(self, service, parcel_count, shipment_id):
+
+    def get_service_dict(self, service, multiplier, shipment_or_order_id, is_order=False):
         available_service = frappe._dict()
-        available_service.service_provider = 'EasyPost'
-        raw_carrier = self.get_carrier(service['carrier'], post_or_get="get")
-        available_service.carrier = self._pretty(raw_carrier)
-        raw_service = service['service']
+        available_service.service_provider = "EasyPost"
+        raw_carrier  = service["carrier"]            # ← add
+        raw_service  = service["service"]            # ← add
+        raw_carrier_api = self.get_carrier(service["carrier"], post_or_get="get")
+        available_service.carrier = self._pretty(raw_carrier_api)
         available_service.service_name = self._pretty(raw_service)
-        available_service.total_price = flt(service['rate']) * parcel_count
-        available_service.delivery_days = service.get('delivery_days')
-        available_service.service_id = service['id']
-        available_service.shipment_id = shipment_id
+        available_service.total_price = flt(service["rate"]) * multiplier
+        available_service.delivery_days = service.get("delivery_days")
+        available_service.service_id = service["id"]
+        available_service.carrier_code = raw_carrier   # ← add
+        available_service.service_code = raw_service   # ← add
+        available_service.shipment_id = None if is_order else shipment_or_order_id
+        available_service.order_id    = shipment_or_order_id if is_order else None
+        available_service.is_order    = is_order
         return available_service
 
     def get_carrier(self, carrier_name, post_or_get=None):
         if carrier_name in ("easypost", "EasyPost"):
             return "EasyPost" if post_or_get == "get" else "easypost"
-        else:
-            return carrier_name.upper() if post_or_get == "get" else carrier_name.lower()
-    
+        return carrier_name.upper() if post_or_get == "get" else carrier_name.lower()
+
+    # ------------------------------------------------------------------
+    # Private helper to store a base‑64 label image and return public URL
+    # ------------------------------------------------------------------
     def _save_base64_png(self, data_uri: str) -> str:
-        """
-        Decode a data-URI, rotate it 90° clockwise, save as a *private* File,
-        create the matching File Doc, and return the absolute URL.
-        """
         if not data_uri or not data_uri.startswith("data:image"):
-            return data_uri                     # already a URL – nothing to do
+            return data_uri
 
         header, b64 = data_uri.split(",", 1)
-        ext   = header.split("/")[1].split(";")[0]          # "png", "gif", …
+        ext = header.split("/")[1].split(";")[0]
 
-        # ── decode base-64 → bytes ───────────────────────────────────────
         raw_bytes = base64.b64decode(b64)
-
-        # ▲ ROTATE the image upright with Pillow
         img = Image.open(io.BytesIO(raw_bytes))
-        img = img.rotate(-90, expand=True)                  # -90 = 90° clockwise
+        img = img.rotate(-90, expand=True)  # 90° clockwise
 
-        # save the rotated image to disk
         fname = f"{uuid.uuid4()}.{ext}"
         file_path = os.path.join(get_files_path(is_private=True), fname)
         img.save(file_path, format=ext.upper())
 
-        # ── register a File doc so /private/files/* isn’t “Forbidden” ────
         file_doc = frappe.get_doc({
             "doctype":   "File",
             "file_name": fname,
@@ -451,9 +675,64 @@ class EasyPostUtils():
         })
         file_doc.insert(ignore_permissions=True)
 
-        return f"{frappe.utils.get_url()}{file_doc.file_url}"
+        return f"{get_url()}{file_doc.file_url}"
+
+    # ----------------------------------------------------------------------
+    # Combine N remote PNGs into one multi-page PDF and return the File URL
+    # ----------------------------------------------------------------------
+    def _png_to_pdf(self, url: str) -> str:
+        """Wrap single-item call so we don’t keep writing [url]."""
+        return self._pngs_to_pdf([url])
 
 
-    def test(self):
-        frappe.msg("gello")
+    def _pngs_to_pdf(self, urls: list[str]) -> str:
+        imgs: list[Image.Image] = []
 
+        for url in urls:
+            img = self._open_label_image(url)
+            # im = im.rotate(-90, expand=True)
+            imgs.append(img)
+
+        if not imgs:
+            frappe.throw(_("No PNGs were supplied for PDF merge."))
+
+        fname = f"{uuid.uuid4()}.pdf"
+        file_path = os.path.join(get_files_path(is_private=True), fname)
+
+        # write a multi-page PDF – Pillow does this if save_all=True
+        imgs[0].save(
+            file_path,
+            "PDF",
+            save_all=True,
+            append_images=imgs[1:]
+        )
+
+        file_doc = frappe.get_doc({
+            "doctype":   "File",
+            "file_name": fname,
+            "file_url":  f"/private/files/{fname}",
+            "is_private": 1,
+        }).insert(ignore_permissions=True)
+
+        return f"{get_url()}{file_doc.file_url}"
+
+    # ----------------------------------------------------------------------
+    # Open a label image whether it lives on S3 or in /private/files
+    # ----------------------------------------------------------------------
+    def _open_label_image(self, url: str) -> "Image":
+        """
+        • For remote (S3) links   → GET over HTTP.
+        • For local /private/…    → read directly from the filesystem
+          so we don’t need authentication cookies.
+        """
+        # Is it one of *our* private files?
+        base = get_url().rstrip("/")            # e.g. https://erp.caseclub.com
+        if url.startswith(f"{base}/private/files/"):
+            fname = url.split("/private/files/")[1]
+            file_path = os.path.join(get_files_path(is_private=True), fname)
+            return Image.open(file_path).convert("RGB")
+
+        # Otherwise download
+        r = requests.get(url, timeout=20)
+        r.raise_for_status()
+        return Image.open(io.BytesIO(r.content)).convert("RGB")

--- a/erpnext_shipping/erpnext_shipping/doctype/easypost/easypost.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/easypost/easypost.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024, Frappe and contributors
 # For license information, please see license.txt
 #frappe.log_error(title="Bill_3p 2", message=f"bill_3p: {bill_3p}, clean_acct: {acct_3p}")
+#/apps/erpnext_shipping/erpnext_shipping/erpnext_shipping/doctype/easypost
 import json
 import base64
 import io
@@ -20,8 +21,8 @@ from requests.exceptions import HTTPError
 
 from erpnext_shipping.erpnext_shipping.utils import show_error_alert
 
-# UPS‑Direct imports -----------------------------------------------------------
-from .ups_direct import UPSDirect, UPS_SHIPPER_NUM
+# UPS-Direct imports -----------------------------------------------------------
+from .ups_direct import UPSDirect
 
 EASYPOST_PROVIDER = "EasyPost"
 
@@ -67,7 +68,8 @@ class EasyPostUtils:
     # ──────────────────────────────────────────────────────────────────────
     _DISPLAY_MAP = {
         # ---- Carrier aliases the rest of the code expects ----
-        "FEDEXDEFAULT": "FedEx",
+        "FEDEXDEFAULT": "FedEx (Easy Post)",
+        "FEDEX":        "FedEx (Case Club)",
         "UPSDAP":       "UPS",
         "USPS":         "USPS",
         # ---- Service renames (add / edit as you like) ----
@@ -132,8 +134,8 @@ class EasyPostUtils:
             ship_doc.get("custom_ship_on_third_party") in (1, "1", True, "Yes")
             and bool(ship_doc.get("custom_third_party_account"))
         )
-        acct_3p  = ship_doc.custom_third_party_account
-        clean_acct = re.sub(r"[^A-Za-z0-9]", "", acct_3p)
+        acct_3p     = ship_doc.custom_third_party_account          # may be None
+        clean_acct  = re.sub(r"[^A-Za-z0-9]", "", acct_3p or "")
         zip_3p   = ship_doc.custom_third_party_postal
         
         if bill_3p and len(clean_acct) == 6:          
@@ -164,7 +166,7 @@ class EasyPostUtils:
                 "state":   delivery_address.state,
                 "zip":     delivery_address.pincode,
                 "country": delivery_address.country,
-                "phone":   delivery_contact.phone,
+                "phone":   self._phone(delivery_contact, delivery_address),
             },
             "from_address": {
                 "name":    f"{pickup_contact.first_name} {pickup_contact.last_name}",
@@ -174,7 +176,7 @@ class EasyPostUtils:
                 "state":   pickup_address.state,
                 "zip":     pickup_address.pincode,
                 "country": pickup_address.country,
-                "phone":   pickup_contact.phone,
+                "phone":   self._phone(pickup_contact, pickup_address),
             },
             **parcel_block,           # ← single or multi‑piece
             "options": {
@@ -221,6 +223,8 @@ class EasyPostUtils:
                     is_order=mps
                 )
                 available_services.append(available_service)
+            
+            #frappe.log_error(title="available_services from easypost", message=f"{available_services}")
 
             # ─────────────────────────────────────────────────────────────
             # UPSDirect integration for third‑party UPS billing (single‑parcel)
@@ -230,7 +234,7 @@ class EasyPostUtils:
                 ups = UPSDirect()
                 try:
                     ups_rates = ups.rate(
-                        UPS_SHIPPER_NUM,
+                        ups.ups_shipper_num,
                         clean_acct,
                         zip_3p.strip(),
                         shipment["to_address"],
@@ -260,7 +264,7 @@ class EasyPostUtils:
                                 "delivery_days":    rated.get("GuaranteedDaysToDelivery"),
                                 "service_id":       code,
                                 "shipment_id":      None,
-                                "ups_shipper_number": UPS_SHIPPER_NUM,
+                                "ups_shipper_number": ups.ups_shipper_num,
                                 "ups_account":        clean_acct,
                                 "ups_postal_code":    zip_3p.strip(),
                                 "to_address":         shipment["to_address"],
@@ -736,3 +740,25 @@ class EasyPostUtils:
         r = requests.get(url, timeout=20)
         r.raise_for_status()
         return Image.open(io.BytesIO(r.content)).convert("RGB")
+    
+    # ─────────────────────────────────────────────
+    # Helper: always return a non-blank phone string
+    # ─────────────────────────────────────────────
+    def _phone(self, contact, address) -> str:
+        """
+        FedEx's REST API will error if `phone` is missing or null.
+        Priority:
+          1) contact.phone
+          2) address.phone  (Address DocType has an optional phone field)
+          3) Company default phone (Settings → Company)
+          4) hard-coded fallback so test mode never blows up
+        """
+        return (
+            (getattr(contact, "phone", "") or "").strip()
+            or (getattr(address, "phone", "") or "").strip()
+            or frappe.db.get_single_value("Company", "phone_no")  # may be None
+            or "714-555-0000"     # ← safe dummy; change to whatever you like
+        )
+
+
+

--- a/erpnext_shipping/erpnext_shipping/doctype/easypost/ups_direct.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/easypost/ups_direct.py
@@ -1,0 +1,273 @@
+# apps/erpnext_shipping/erpnext_shipping/utils/ups_direct.py
+import requests, json, datetime, uuid
+import frappe
+from requests.exceptions import HTTPError
+
+# --- HARD-CODED creds for POC ---
+UPS_CLIENT_ID     = "UPS_CLIENT_ID"
+UPS_CLIENT_SECRET = "UPS_CLIENT_SECRET"
+UPS_SHIPPER_NUM   = "UPS_SHIPPER_NUM"          # your own 6-char account
+
+# Endpoints (test vs prod)
+UPS_BASE_URL   = "https://wwwcie.ups.com"          # ← add this constant
+UPS_OAUTH_URL  = f"{UPS_BASE_URL}/security/v1/oauth/token"
+UPS_RATE_URL = f"{UPS_BASE_URL}/api/rating/v2205/Shop"   # <— path param
+UPS_SHIP_URL   = f"{UPS_BASE_URL}/api/shipments/v1/ship"
+
+class UPSDirect:
+    def __init__(self):
+        self.token = self._oauth()
+        self._base_url = UPS_BASE_URL
+    
+    SERVICE_MAP = {
+        # Domestic
+        "01": "Next Day Air",
+        "02": "2nd Day Air",
+        "03": "Ground",
+        "12": "3-Day Select",
+        "13": "Next Day Air Saver",
+        "14": "Next Day Air Early A.M.",
+        "59": "2nd Day Air A.M.",
+
+        # International
+        "07": "Worldwide Express",
+        "08": "Worldwide Expedited",
+        "11": "Standard",
+        "54": "Worldwide Express Plus",
+        "65": "Worldwide Saver",
+        "96": "Worldwide Express Freight",
+
+        # SurePost
+        "92": "SurePost Less than 1 lb",
+        "93": "SurePost 1 lb or Greater",
+        "94": "SurePost BPM",
+        "95": "SurePost Media Mail",
+
+        # Access Point
+        "70": "Access Point Economy",
+
+        # Today (same-day) services
+        "82": "Today Standard",
+        "83": "Today Dedicated Courier",
+        "84": "Today Intercity",
+        "85": "Today Express",
+        "86": "Today Express Saver",
+    }
+
+    
+    def _headers(self) -> dict:
+        return {
+            "Authorization": f"Bearer {self.token}",      # the OAuth token
+            "x-merchant-id": UPS_CLIENT_ID,               # ← back to client-id
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "transId": str(uuid.uuid4()),
+            "transactionSrc": "ERPNext",
+        }
+
+    # ---------- auth ----------
+    def _oauth(self):
+        # UPS wants Basic auth + x-merchant-id on the token request
+        import base64
+
+        # construct Basic header
+        creds = f"{UPS_CLIENT_ID}:{UPS_CLIENT_SECRET}".encode("utf-8")
+        basic_token = base64.b64encode(creds).decode("utf-8")
+
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+            "x-merchant-id": UPS_CLIENT_ID,
+            "Authorization": f"Basic {basic_token}",
+        }
+        payload = "grant_type=client_credentials"
+
+        r = requests.post(
+            UPS_OAUTH_URL,
+            headers=headers,
+            data=payload
+        )
+        r.raise_for_status()
+        return r.json()["access_token"]
+
+    # ---------- build helpers ----------
+    def _address(self, d):
+        return {
+            "Address": {
+                "AddressLine": [d["street1"]],
+                "City": d["city"],
+                "StateProvinceCode": d["state"],
+                "PostalCode": d["zip"],
+                "CountryCode": "US",
+            }
+        }
+
+
+    def _package(self, parcel):
+        """
+        Build a Package block that satisfies both the /Shop (rating)
+        and /ship (buy label) endpoints.
+        """
+        dims = {
+            "UnitOfMeasurement": {"Code": "IN"},
+            "Length": str(parcel["length"]),
+            "Width":  str(parcel["width"]),
+            "Height": str(parcel["height"]),
+        }
+        weight = {
+            "UnitOfMeasurement": {"Code": "LBS"},
+            "Weight": str(parcel["weight"] / 16.0)   # oz ➜ lb
+        }
+
+        return {
+            # NEW field name for the Ship API
+            "Packaging":      {"Code": "02"},        # 02 = Your Package
+            # Legacy field retained so the Rate API keeps working
+            "PackagingType":  {"Code": "02"},
+            "Dimensions":     dims,
+            "PackageWeight":  weight,
+        }
+
+
+    # ---------- rate ----------
+    def rate(self, shipper_num, bill_acct, bill_zip, to_addr, from_addr, parcel):
+        body = {
+            "RateRequest": {
+                 "Request": {
+                     "SubVersion": "2205"
+                 },
+                "PickupType": {                  # ← Pascal-case
+                    "Code": "03"                 # 03 = Customer Counter
+                },
+                "CustomerClassification": {
+                    "Code": "04"                 # 04 = Occasional Shipper
+                },
+                "Shipment": {
+                    "Shipper": {
+                        "Name": "Case Club",
+                        "ShipperNumber": shipper_num,
+                        **self._address(from_addr)        # returns {"Address":{…}}
+                    },
+                    "ShipFrom": self._address(from_addr),
+                    "ShipTo":   self._address(to_addr),
+                    "Package": [ self._package(parcel) ]   # ← Pascal-case
+                }
+            }
+        }
+
+        r = requests.post(UPS_RATE_URL, json=body, headers=self._headers(), timeout=30)
+
+        if r.status_code >= 400:
+            body_text = r.text.strip() or "(empty)"
+            frappe.log_error(f"UPS {r.status_code} response", body_text)
+            # try to pull JSON errors, but fall back to raw text
+            try:
+                err = r.json()
+            except ValueError:
+                err = body_text
+            raise HTTPError(f"UPS error {r.status_code}: {err}", response=r)
+
+        
+        # Print the raw ups rate response
+        #print("RAW UPS RATE RESPONSE:", json.dumps(r.json(), indent=2), flush=True)
+
+        r.raise_for_status()
+        return r.json()
+
+
+
+    # ---------- ship / buy ----------
+    def ship(self, shipper_num, bill_acct, bill_zip, to_addr, from_addr, parcel, service_code):
+        today = datetime.date.today().strftime("%Y%m%d")      
+
+        if bill_acct and bill_acct.strip() != shipper_num:
+            # third-party billing
+            payer_block = {
+                "Type": "01",                 # 01 = transportation charges
+                "BillThirdParty": {
+                    "AccountNumber": bill_acct.strip(),
+                    "Address": {
+                        "PostalCode": bill_zip,
+                        "CountryCode": "US"
+                    }
+                }
+            }
+        else:
+            # shipper pays
+            payer_block = {
+                "Type": "01",
+                "BillShipper": {
+                    "AccountNumber": shipper_num
+                }
+            }
+
+        body = {
+            "ShipmentRequest": {
+                "Request": {"SubVersion": "2205"},
+                "Shipment": {
+                    "Shipper":  self._shipper("Case Club", shipper_num, from_addr),
+                    "ShipFrom": self._party(from_addr.get("name"),  from_addr),
+                    "ShipTo":   self._party(to_addr.get("name"),    to_addr),
+                    "Service": {"Code": service_code},
+                    "PaymentInformation": {
+                        "ShipmentCharge": [payer_block]
+                    },
+                    "Package": [self._package(parcel)],
+                    "ShipmentDate": today,
+                },
+                "LabelSpecification": {
+                    "LabelImageFormat": {"Code": "PNG"},
+                    "LabelDelivery":    {"LabelLinkIndicator": "true"}
+                }
+            }
+        }
+        #print(f"Ship Payload: {body}", flush=True)
+        frappe.log_error("DEBUG UPS ship URL", UPS_SHIP_URL)
+        r = requests.post(UPS_SHIP_URL, json=body, headers=self._headers())
+        if r.status_code >= 400:
+            frappe.log_error(
+                title=f"UPS {r.status_code} body",
+                message=r.text[:2000] or "(empty)"
+            )
+            r.raise_for_status()
+        
+        #print("RAW UPS Ship RESPONSE:", json.dumps(r.json(), indent=2), flush=True)
+        
+        r.raise_for_status()
+        return r.json()
+    
+
+    # --- new helpers -----------------------------------------------------------
+    def _shipper(self, nickname: str, acct_no: str, addr: dict) -> dict:
+        """Block for the mandatory Shipper object."""
+        block = {
+            "Name": nickname,               # required
+            "ShipperNumber": acct_no,       # required
+            "Address": self._address(addr)["Address"],
+        }
+        # label looks nicer with a contact name too
+        if addr.get("name"):
+            block["AttentionName"] = addr["name"]
+        return block
+
+
+    def _party(self, person_or_co: str, addr: dict) -> dict:
+        """
+        Build a ShipFrom / ShipTo object.
+
+        If you pass a business name put it in CompanyName **and** duplicate it
+        into AttentionName;  
+        if it’s an individual pass it only as Name.
+        """
+        if addr.get("company"):                      # commercial address
+            return {
+                "CompanyName": person_or_co,
+                "AttentionName": person_or_co,
+                "Address": self._address(addr)["Address"],
+            }
+        # residential / individual ­– UPS wants Name
+        return {
+            "Name": person_or_co,
+            "Address": self._address(addr)["Address"],
+        }
+

--- a/erpnext_shipping/erpnext_shipping/doctype/easypost/ups_direct.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/easypost/ups_direct.py
@@ -1,6 +1,7 @@
 # apps/erpnext_shipping/erpnext_shipping/utils/ups_direct.py
 import requests, json, datetime, uuid
 import frappe
+import re
 from requests.exceptions import HTTPError
 
 # --- HARD-CODED creds for POC ---
@@ -13,6 +14,12 @@ UPS_BASE_URL   = "https://wwwcie.ups.com"          # ← add this constant
 UPS_OAUTH_URL  = f"{UPS_BASE_URL}/security/v1/oauth/token"
 UPS_RATE_URL = f"{UPS_BASE_URL}/api/rating/v2205/Shop"   # <— path param
 UPS_SHIP_URL   = f"{UPS_BASE_URL}/api/shipments/v1/ship"
+
+def build_parcel_list(rows):
+    parcels = []
+    for p in rows:
+        parcels.append(p.copy())      # rows are already dicts here
+    return parcels
 
 class UPSDirect:
     def __init__(self):
@@ -102,6 +109,17 @@ class UPSDirect:
             }
         }
 
+    def _phone(self, raw: str | None) -> dict | None:
+        """
+        Return {"Phone": {"Number": "7147798794"}}  or  None.
+        UPS wants 10–15 digits, no punctuation.
+        """
+        if not raw:
+            return None
+        num = re.sub(r"\D", "", raw)[:15]
+        if len(num) < 10:        # UPS rejects shorter numbers
+            return None
+        return {"Phone": {"Number": num}}
 
     def _package(self, parcel):
         """
@@ -130,7 +148,7 @@ class UPSDirect:
 
 
     # ---------- rate ----------
-    def rate(self, shipper_num, bill_acct, bill_zip, to_addr, from_addr, parcel):
+    def rate(self, shipper_num, bill_acct, bill_zip, to_addr, from_addr, parcels):
         body = {
             "RateRequest": {
                  "Request": {
@@ -150,7 +168,7 @@ class UPSDirect:
                     },
                     "ShipFrom": self._address(from_addr),
                     "ShipTo":   self._address(to_addr),
-                    "Package": [ self._package(parcel) ]   # ← Pascal-case
+                    "Package": [self._package(p) for p in parcels]
                 }
             }
         }
@@ -177,9 +195,9 @@ class UPSDirect:
 
 
     # ---------- ship / buy ----------
-    def ship(self, shipper_num, bill_acct, bill_zip, to_addr, from_addr, parcel, service_code):
+    def ship(self, shipper_num, bill_acct, bill_zip, to_addr, from_addr, parcels, service_code):
         today = datetime.date.today().strftime("%Y%m%d")      
-
+        
         if bill_acct and bill_acct.strip() != shipper_num:
             # third-party billing
             payer_block = {
@@ -212,7 +230,7 @@ class UPSDirect:
                     "PaymentInformation": {
                         "ShipmentCharge": [payer_block]
                     },
-                    "Package": [self._package(parcel)],
+                    "Package": [self._package(p) for p in parcels],
                     "ShipmentDate": today,
                 },
                 "LabelSpecification": {
@@ -248,26 +266,33 @@ class UPSDirect:
         # label looks nicer with a contact name too
         if addr.get("name"):
             block["AttentionName"] = addr["name"]
+            
+        phone_block = self._phone(addr.get("phone"))
+        if phone_block:
+            block.update(phone_block)
+        
         return block
 
 
     def _party(self, person_or_co: str, addr: dict) -> dict:
-        """
-        Build a ShipFrom / ShipTo object.
-
-        If you pass a business name put it in CompanyName **and** duplicate it
-        into AttentionName;  
-        if it’s an individual pass it only as Name.
-        """
-        if addr.get("company"):                      # commercial address
-            return {
-                "CompanyName": person_or_co,
+        # Base block
+        if addr.get("company"):  # commercial address
+            block = {
+                "CompanyName":   person_or_co,
+                "AttentionName": person_or_co,
+                "Address":       self._address(addr)["Address"],
+            }
+        else:  # residential / individual – UPS wants Name
+            block = {
+                "Name":    person_or_co,
                 "AttentionName": person_or_co,
                 "Address": self._address(addr)["Address"],
             }
-        # residential / individual ­– UPS wants Name
-        return {
-            "Name": person_or_co,
-            "Address": self._address(addr)["Address"],
-        }
+
+        # Inject phone when valid
+        phone_block = self._phone(addr.get("phone"))
+        if phone_block:
+            block.update(phone_block)
+
+        return block
 

--- a/erpnext_shipping/erpnext_shipping/doctype/easypost/ups_direct.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/easypost/ups_direct.py
@@ -23,9 +23,14 @@ def _get_ups_creds():
     return client_id, secret, shipper
 
 # Endpoints (test vs prod)
-UPS_BASE_URL   = "https://wwwcie.ups.com"          # ← add this constant
+def _get_ups_base_url():
+    docname = "EasyPost"
+    use_test = frappe.db.get_single_value(docname, "use_test_environment")
+    return "https://wwwcie.ups.com" if use_test else "https://onlinetools.ups.com"
+
+UPS_BASE_URL   = _get_ups_base_url()
 UPS_OAUTH_URL  = f"{UPS_BASE_URL}/security/v1/oauth/token"
-UPS_RATE_URL = f"{UPS_BASE_URL}/api/rating/v2205/Shop"   # <— path param
+UPS_RATE_URL = f"{UPS_BASE_URL}/api/rating/v2205/Shop"
 UPS_SHIP_URL   = f"{UPS_BASE_URL}/api/shipments/v1/ship"
 
 def build_parcel_list(rows):
@@ -310,4 +315,3 @@ class UPSDirect:
             block.update(phone_block)
 
         return block
-

--- a/erpnext_shipping/erpnext_shipping/doctype/easypost/ups_direct.py
+++ b/erpnext_shipping/erpnext_shipping/doctype/easypost/ups_direct.py
@@ -1,13 +1,26 @@
 # apps/erpnext_shipping/erpnext_shipping/utils/ups_direct.py
+#/apps/erpnext_shipping/erpnext_shipping/erpnext_shipping/doctype/easypost
 import requests, json, datetime, uuid
 import frappe
+from frappe.utils.password import get_decrypted_password
 import re
 from requests.exceptions import HTTPError
 
-# --- HARD-CODED creds for POC ---
-UPS_CLIENT_ID     = "UPS_CLIENT_ID"
-UPS_CLIENT_SECRET = "UPS_CLIENT_SECRET"
-UPS_SHIPPER_NUM   = "UPS_SHIPPER_NUM"          # your own 6-char account
+def _get_ups_creds():
+    """
+    Load UPS creds from the EasyPost singleton at runtime.
+    Avoids frappe calls at import-time which break method resolution.
+    """
+    # EasyPost is a singleton doctype
+    docname = "EasyPost"
+    client_id = frappe.db.get_single_value(docname, "custom_ups_client_id")
+    shipper  = frappe.db.get_single_value(docname, "custom_ups_shipper_number")
+    # Use the low-level decryptor so we don't need a Document at import time
+    secret   = get_decrypted_password(docname, docname, "custom_ups_client_secret", raise_exception=False)
+
+    if not client_id or not secret or not shipper:
+        frappe.throw("UPS credentials are missing in EasyPost settings (client id/secret/shipper).")
+    return client_id, secret, shipper
 
 # Endpoints (test vs prod)
 UPS_BASE_URL   = "https://wwwcie.ups.com"          # ← add this constant
@@ -23,6 +36,8 @@ def build_parcel_list(rows):
 
 class UPSDirect:
     def __init__(self):
+        # pull creds now (runtime), not at import time
+        self.ups_client_id, self.ups_client_secret, self.ups_shipper_num = _get_ups_creds()
         self.token = self._oauth()
         self._base_url = UPS_BASE_URL
     
@@ -64,8 +79,8 @@ class UPSDirect:
     
     def _headers(self) -> dict:
         return {
-            "Authorization": f"Bearer {self.token}",      # the OAuth token
-            "x-merchant-id": UPS_CLIENT_ID,               # ← back to client-id
+            "Authorization": f"Bearer {self.token}",
+            "x-merchant-id": self.ups_client_id,
             "Accept": "application/json",
             "Content-Type": "application/json",
             "transId": str(uuid.uuid4()),
@@ -78,13 +93,13 @@ class UPSDirect:
         import base64
 
         # construct Basic header
-        creds = f"{UPS_CLIENT_ID}:{UPS_CLIENT_SECRET}".encode("utf-8")
+        creds = f"{self.ups_client_id}:{self.ups_client_secret}".encode("utf-8")
         basic_token = base64.b64encode(creds).decode("utf-8")
 
         headers = {
             "Content-Type": "application/x-www-form-urlencoded",
             "Accept": "application/json",
-            "x-merchant-id": UPS_CLIENT_ID,
+            "x-merchant-id": self.ups_client_id,
             "Authorization": f"Basic {basic_token}",
         }
         payload = "grant_type=client_credentials"

--- a/erpnext_shipping/erpnext_shipping/shipping.py
+++ b/erpnext_shipping/erpnext_shipping/shipping.py
@@ -1,271 +1,520 @@
 # Copyright (c) 2020, Frappe Technologies and contributors
 # For license information, please see license.txt
+import base64
+import uuid
 import json
-
+import os
+import requests
 import frappe
 from erpnext.stock.doctype.shipment.shipment import get_company_contact
+from frappe import _
 
 from erpnext_shipping.erpnext_shipping.doctype.letmeship.letmeship import (
-	LETMESHIP_PROVIDER,
-	get_letmeship_utils,
+    LETMESHIP_PROVIDER,
+    get_letmeship_utils,
 )
 from erpnext_shipping.erpnext_shipping.doctype.sendcloud.sendcloud import SENDCLOUD_PROVIDER, SendCloudUtils
 from erpnext_shipping.erpnext_shipping.utils import (
-	get_address,
-	get_contact,
-	match_parcel_service_type_carrier,
+    get_address,
+    get_contact,
+    match_parcel_service_type_carrier,
 )
 
+from erpnext_shipping.erpnext_shipping.doctype.easypost.easypost import EASYPOST_PROVIDER, EasyPostUtils
+
+from frappe.utils.file_manager import get_files_path
 
 @frappe.whitelist()
 def fetch_shipping_rates(
-	pickup_from_type,
-	delivery_to_type,
-	pickup_address_name,
-	delivery_address_name,
-	parcels,
-	description_of_content,
-	pickup_date,
-	value_of_goods,
-	pickup_contact_name=None,
-	delivery_contact_name=None,
+    pickup_from_type,
+    delivery_to_type,
+    pickup_address_name,
+    delivery_address_name,
+    parcels,
+    description_of_content,
+    pickup_date,
+    value_of_goods,
+    pickup_contact_name=None,
+    delivery_contact_name=None,
 ):
-	# Return Shipping Rates for the various Shipping Providers
-	shipment_prices = []
-	letmeship_enabled = frappe.db.get_single_value("LetMeShip", "enabled")
-	sendcloud_enabled = frappe.db.get_single_value("SendCloud", "enabled")
-	pickup_address = get_address(pickup_address_name)
-	delivery_address = get_address(delivery_address_name)
-	parcels = json.loads(parcels)
+    # Return Shipping Rates for the various Shipping Providers
+    shipment_prices = []
+    letmeship_enabled = frappe.db.get_single_value("LetMeShip", "enabled")
+    sendcloud_enabled = frappe.db.get_single_value("SendCloud", "enabled")
+    easypost_enabled = frappe.db.get_single_value("EasyPost", "enabled")
+    pickup_address = get_address(pickup_address_name)
+    delivery_address = get_address(delivery_address_name)
+    parcels = json.loads(parcels)
 
-	if letmeship_enabled:
-		pickup_contact = None
-		delivery_contact = None
-		if pickup_from_type != "Company":
-			pickup_contact = get_contact(pickup_contact_name)
-		else:
-			pickup_contact = get_company_contact(user=pickup_contact_name)
-			pickup_contact.email_id = pickup_contact.pop("email", None)
+    if letmeship_enabled:
+        pickup_contact = None
+        delivery_contact = None
+        if pickup_from_type != "Company":
+            pickup_contact = get_contact(pickup_contact_name)
+        else:
+            pickup_contact = get_company_contact(user=pickup_contact_name)
+            pickup_contact.email_id = pickup_contact.pop("email", None)
 
-		if delivery_to_type != "Company":
-			delivery_contact = get_contact(delivery_contact_name)
-		else:
-			delivery_contact = get_company_contact(user=pickup_contact_name)
-			delivery_contact.email_id = delivery_contact.pop("email", None)
+        delivery_contact = get_contact(delivery_contact_name)
 
-		letmeship = get_letmeship_utils()
-		letmeship_prices = (
-			letmeship.get_available_services(
-				delivery_to_type=delivery_to_type,
-				pickup_address=pickup_address,
-				delivery_address=delivery_address,
-				parcels=parcels,
-				description_of_content=description_of_content,
-				pickup_date=pickup_date,
-				value_of_goods=value_of_goods,
-				pickup_contact=pickup_contact,
-				delivery_contact=delivery_contact,
-			)
-			or []
-		)
-		letmeship_prices = match_parcel_service_type_carrier(letmeship_prices, "carrier", "service_name")
-		shipment_prices += letmeship_prices
+        letmeship = get_letmeship_utils()
+        letmeship_prices = (
+            letmeship.get_available_services(
+                delivery_to_type=delivery_to_type,
+                pickup_address=pickup_address,
+                delivery_address=delivery_address,
+                parcels=parcels,
+                description_of_content=description_of_content,
+                pickup_date=pickup_date,
+                value_of_goods=value_of_goods,
+                pickup_contact=pickup_contact,
+                delivery_contact=delivery_contact,
+            )
+            or []
+        )
+        letmeship_prices = match_parcel_service_type_carrier(letmeship_prices, "carrier", "service_name")
+        shipment_prices += letmeship_prices
 
-	if sendcloud_enabled and pickup_from_type == "Company":
-		sendcloud = SendCloudUtils()
-		sendcloud_prices = (
-			sendcloud.get_available_services(delivery_address=delivery_address, parcels=parcels) or []
-		)
-		sendcloud_prices = match_parcel_service_type_carrier(sendcloud_prices, "carrier", "service_name")
-		shipment_prices += sendcloud_prices
+    if sendcloud_enabled and pickup_from_type == "Company":
+        sendcloud = SendCloudUtils()
+        sendcloud_prices = (
+            sendcloud.get_available_services(delivery_address=delivery_address, parcels=parcels) or []
+        )
+        sendcloud_prices = match_parcel_service_type_carrier(sendcloud_prices, "carrier", "service_name")
+        shipment_prices += sendcloud_prices
 
-	shipment_prices = sorted(shipment_prices, key=lambda k: k["total_price"])
-	return shipment_prices
+    if easypost_enabled and len(parcels) == 1:
+        pickup_contact = None
+        delivery_contact = None
+        if pickup_from_type != "Company":
+            pickup_contact = get_contact(pickup_contact_name)
+        else:
+            pickup_contact = get_company_contact(user=pickup_contact_name)
+            pickup_contact.email_id = pickup_contact.pop("email", None)
 
+        # if delivery_to_type != "Company":
+        #     delivery_contact = get_contact(delivery_contact_name)
+        # else:
+        #     delivery_contact = get_company_contact(user=pickup_contact_name)
+        #     delivery_contact.email_id = delivery_contact.pop("email", None)
+
+        delivery_contact = get_contact(delivery_contact_name)
+
+        easypost = EasyPostUtils()
+        easypost_prices = (
+            easypost.get_available_services(
+                delivery_address=delivery_address,
+                delivery_contact=delivery_contact,
+                shipment_parcel=parcels,
+                pickup_address=pickup_address,
+                pickup_contact=pickup_contact,
+                value_of_goods=value_of_goods
+            )
+            or []
+        )
+#eric added the following line but does not seem to make a difference
+        easypost_prices = match_parcel_service_type_carrier(easypost_prices, "carrier", "service_name")
+        shipment_prices += easypost_prices
+
+    shipment_prices = sorted(shipment_prices, key=lambda k: k["total_price"])
+    return shipment_prices
+
+def ensure_label_file(shipment_doc, label_value: str) -> str:
+    """
+    Accepts:
+      • data-URI
+      • https:// remote URL
+      • /private/files/…  *or*  https://<this-site>/private/files/…
+    Ensures a File in /private/files **and** attaches it to the Shipment.
+    Returns the absolute URL you can store / print.
+    """
+    if not label_value:
+        return ""
+
+    # ─────────────────────────────────────────────────────────────────
+    # Case 1 – already an internal file (relative OR absolute URL)
+    # -----------------------------------------------------------------
+    site_url = frappe.utils.get_url().rstrip("/")             # e.g. "https://erp.caseclub.com"
+    internal_prefix = f"{site_url}/private/files/"
+
+    if label_value.startswith("/private/files/"):
+        file_url = label_value                                  # already relative
+
+    elif label_value.startswith(internal_prefix):
+        file_url = label_value[len(site_url):]                  # strip site → relative
+
+    # ─────────────────────────────────────────────────────────────────
+    # Case 2 – data-URI  (unchanged)
+    # -----------------------------------------------------------------
+    elif label_value.startswith("data:image"):
+        header, b64 = label_value.split(",", 1)
+        ext   = header.split("/")[1].split(";")[0]
+        fname = f"{uuid.uuid4()}.{ext}"
+        file_path = os.path.join(get_files_path(is_private=True), fname)
+        with open(file_path, "wb") as f:
+            f.write(base64.b64decode(b64))
+        file_url = f"/private/files/{fname}"
+
+    # ─────────────────────────────────────────────────────────────────
+    # Case 3 – genuine remote URL  (unchanged)
+    # -----------------------------------------------------------------
+    else:
+        resp = requests.get(label_value, timeout=15)
+        resp.raise_for_status()
+        ext   = label_value.rsplit(".", 1)[-1].split("?")[0] or "png"
+        fname = f"{uuid.uuid4()}.{ext}"
+        file_path = os.path.join(get_files_path(is_private=True), fname)
+        with open(file_path, "wb") as f:
+            f.write(resp.content)
+        file_url = f"/private/files/{fname}"
+
+    # ────────────────────────────────────────────────────────────
+    # Attach (or re-attach) to the Shipment
+    if not frappe.db.exists(
+        "File",
+        {"file_url": file_url, "attached_to_doctype": "Shipment", "attached_to_name": shipment_doc.name}
+    ):
+        file_doc = frappe.get_doc({
+            "doctype":             "File",
+            "file_name":           os.path.basename(file_url),
+            "file_url":            file_url,
+            "is_private":          1,
+            "attached_to_doctype": "Shipment",
+            "attached_to_name":    shipment_doc.name,
+        })
+        file_doc.insert(ignore_permissions=True)
+
+    return f"{frappe.utils.get_url()}{file_url}"
 
 @frappe.whitelist()
 def create_shipment(
-	shipment,
-	pickup_from_type,
-	delivery_to_type,
-	pickup_address_name,
-	delivery_address_name,
-	shipment_parcel,
-	description_of_content,
-	pickup_date,
-	value_of_goods,
-	service_data,
-	shipment_notific_email=None,
-	tracking_notific_email=None,
-	pickup_contact_name=None,
-	delivery_contact_name=None,
-	delivery_notes=None,
+    shipment,
+    pickup_from_type,
+    delivery_to_type,
+    pickup_address_name,
+    delivery_address_name,
+    shipment_parcel,
+    description_of_content,
+    pickup_date,
+    value_of_goods,
+    service_data,
+    shipment_notific_email=None,
+    tracking_notific_email=None,
+    pickup_contact_name=None,
+    delivery_contact_name=None,
+    delivery_notes=None,
 ):
-	# Create Shipment for the selected provider
-	if delivery_notes is None:
-		delivery_notes = []
+    # Create Shipment for the selected provider
+    if delivery_notes is None:
+        delivery_notes = []
 
-	service_info = json.loads(service_data)
-	shipment_info, pickup_contact, delivery_contact = None, None, None
-	pickup_address = get_address(pickup_address_name)
-	delivery_address = get_address(delivery_address_name)
-	delivery_company_name = get_delivery_company_name(shipment)
+    service_info = json.loads(service_data)
+    shipment_info, pickup_contact, delivery_contact = None, None, None
+    pickup_address = get_address(pickup_address_name)
+    delivery_address = get_address(delivery_address_name)
+    delivery_company_name = get_delivery_company_name(shipment)
 
-	if pickup_from_type != "Company":
-		pickup_contact = get_contact(pickup_contact_name)
-	else:
-		pickup_contact = get_company_contact(user=pickup_contact_name)
-		pickup_contact.email_id = pickup_contact.pop("email", None)
+    if pickup_from_type != "Company":
+        pickup_contact = get_contact(pickup_contact_name)
 
-	if delivery_to_type != "Company":
-		delivery_contact = get_contact(delivery_contact_name)
-	else:
-		delivery_contact = get_company_contact(user=pickup_contact_name)
-		pickup_contact.email_id = pickup_contact.pop("email", None)
+    else:
+        pickup_contact = get_company_contact(user=pickup_contact_name)
+        pickup_contact.email_id = pickup_contact.pop("email", None)
 
-	if service_info["service_provider"] == LETMESHIP_PROVIDER:
-		letmeship = get_letmeship_utils()
-		shipment_info = letmeship.create_shipment(
-			pickup_address=pickup_address,
-			delivery_company_name=delivery_company_name,
-			delivery_address=delivery_address,
-			shipment_parcel=shipment_parcel,
-			description_of_content=description_of_content,
-			pickup_date=pickup_date,
-			value_of_goods=value_of_goods,
-			pickup_contact=pickup_contact,
-			delivery_contact=delivery_contact,
-			service_info=service_info,
-		)
+    delivery_contact = get_contact(delivery_contact_name)
 
-	if service_info["service_provider"] == SENDCLOUD_PROVIDER:
-		sendcloud = SendCloudUtils()
-		shipment_info = sendcloud.create_shipment(
-			shipment=shipment,
-			delivery_company_name=delivery_company_name,
-			delivery_address=delivery_address,
-			shipment_parcel=shipment_parcel,
-			description_of_content=description_of_content,
-			value_of_goods=value_of_goods,
-			delivery_contact=delivery_contact,
-			service_info=service_info,
-		)
+    if service_info["service_provider"] == LETMESHIP_PROVIDER:
+        letmeship = get_letmeship_utils()
+        shipment_info = letmeship.create_shipment(
+            pickup_address=pickup_address,
+            delivery_company_name=delivery_company_name,
+            delivery_address=delivery_address,
+            shipment_parcel=shipment_parcel,
+            description_of_content=description_of_content,
+            pickup_date=pickup_date,
+            value_of_goods=value_of_goods,
+            pickup_contact=pickup_contact,
+            delivery_contact=delivery_contact,
+            service_info=service_info,
+        )
 
-	if shipment_info:
-		shipment = frappe.get_doc("Shipment", shipment)
-		shipment.db_set(
-			{
-				"service_provider": shipment_info.get("service_provider"),
-				"carrier": shipment_info.get("carrier"),
-				"carrier_service": shipment_info.get("carrier_service"),
-				"shipment_id": shipment_info.get("shipment_id"),
-				"shipment_amount": shipment_info.get("shipment_amount"),
-				"awb_number": shipment_info.get("awb_number"),
-				"status": "Booked",
-			}
-		)
+    if service_info["service_provider"] == SENDCLOUD_PROVIDER:
+        sendcloud = SendCloudUtils()
+        shipment_info = sendcloud.create_shipment(
+            shipment=shipment,
+            delivery_company_name=delivery_company_name,
+            delivery_address=delivery_address,
+            shipment_parcel=shipment_parcel,
+            description_of_content=description_of_content,
+            value_of_goods=value_of_goods,
+            delivery_contact=delivery_contact,
+            service_info=service_info,
+        )
 
-		if delivery_notes:
-			update_delivery_note(delivery_notes=delivery_notes, shipment_info=shipment_info)
+    # Handle both EasyPost and direct-UPS purchases here
+    if service_info.get("service_provider") in (EASYPOST_PROVIDER, "UPS"):
+        # convert the incoming dict to frappe._dict so attribute access works
+        if isinstance(service_info, dict):
+            service_info = frappe._dict(service_info)
 
-	return shipment_info
+        easypost = EasyPostUtils()
+        shipment_info = easypost.create_shipment(
+            service_info=service_info,
+            delivery_address=delivery_address
+        )
+
+    if shipment_info:
+        shipment = frappe.get_doc("Shipment", shipment)
+        shipment.db_set(
+            {
+                "service_provider": shipment_info.get("service_provider"),
+                "carrier": shipment_info.get("carrier"),
+                "carrier_service": shipment_info.get("carrier_service"),
+                "shipment_id": shipment_info.get("shipment_id"),
+                "shipment_amount": shipment_info.get("shipment_amount"),
+                "awb_number": shipment_info.get("awb_number"),
+                "status": "Booked",
+            }
+        )
+        # ------------------------------------------------------------------
+        # Save custom UPS label info so the UI buttons have something to open
+        # ------------------------------------------------------------------
+        if shipment_info.get("shipping_label"):
+            try:
+                file_url = ensure_label_file(shipment, shipment_info["shipping_label"])
+                shipment.db_set("custom_shipping_label", file_url)
+            except frappe.DoesNotExistError:
+                pass                          # site hasn't got the custom field yet
+
+        if shipment_info.get("postage_label"):
+            try:
+                shipment.db_set("custom_postage_label", json.dumps(shipment_info["postage_label"]))
+            except frappe.DoesNotExistError:
+                pass
+
+                if delivery_notes:
+                    update_delivery_note(delivery_notes=delivery_notes, shipment_info=shipment_info)
+
+    return shipment_info
 
 
 def get_delivery_company_name(shipment: str) -> str | None:
-	shipment_doc = frappe.get_doc("Shipment", shipment)
-	if shipment_doc.delivery_customer:
-		return frappe.db.get_value("Customer", shipment_doc.delivery_customer, "customer_name")
-	if shipment_doc.delivery_supplier:
-		return frappe.db.get_value("Supplier", shipment_doc.delivery_supplier, "supplier_name")
-	if shipment_doc.delivery_company:
-		return frappe.db.get_value("Company", shipment_doc.delivery_company, "company_name")
+    shipment_doc = frappe.get_doc("Shipment", shipment)
+    if shipment_doc.delivery_customer:
+        return frappe.db.get_value("Customer", shipment_doc.delivery_customer, "customer_name")
+    if shipment_doc.delivery_supplier:
+        return frappe.db.get_value("Supplier", shipment_doc.delivery_supplier, "supplier_name")
+    if shipment_doc.delivery_company:
+        return frappe.db.get_value("Company", shipment_doc.delivery_company, "company_name")
 
-	return None
+    return None
 
 
+#standard label printing
 @frappe.whitelist()
 def print_shipping_label(shipment: str):
-	shipment_doc = frappe.get_doc("Shipment", shipment)
-	service_provider = shipment_doc.service_provider
-	shipment_id = shipment_doc.shipment_id
+    shipment_doc = frappe.get_doc("Shipment", shipment)
+    service_provider = shipment_doc.service_provider
+    shipment_id = shipment_doc.shipment_id
 
-	if service_provider == LETMESHIP_PROVIDER:
-		letmeship = get_letmeship_utils()
-		shipping_label = letmeship.get_label(shipment_id)
-	elif service_provider == SENDCLOUD_PROVIDER:
-		sendcloud = SendCloudUtils()
-		shipping_label = []
-		_labels = sendcloud.get_label(shipment_id)
-		for label_url in _labels:
-			content = sendcloud.download_label(label_url)
-			file_url = save_label_as_attachment(shipment, content)
-			shipping_label.append(file_url)
+    if service_provider == LETMESHIP_PROVIDER:
+        letmeship = get_letmeship_utils()
+        shipping_label = letmeship.get_label(shipment_id)
+    elif service_provider == SENDCLOUD_PROVIDER:
+        sendcloud = SendCloudUtils()
+        shipping_label = []
+        _labels = sendcloud.get_label(shipment_id)
+        for label_url in _labels:
+            content = sendcloud.download_label(label_url)
+            file_url = save_label_as_attachment(shipment, content)
+            shipping_label.append(file_url)
+    elif service_provider == EASYPOST_PROVIDER:
+        easypost = EasyPostUtils()
+        shipping_label = easypost.get_label(shipment_id)
+    elif service_provider == "UPS":
+        # 1) try direct URL saved earlier
+        shipping_label = shipment_doc.get("custom_shipping_label")
 
-	return shipping_label
+        # 2) fall back to extracting from the JSON blob (in case the first save failed)
+        if (not shipping_label) and shipment_doc.get("custom_postage_label"):
+            try:
+                pl = json.loads(shipment_doc.custom_postage_label)
+                shipping_label = (
+                    pl.get("label_url") or
+                    pl.get("label_png_url")
+                )
+            except Exception:
+                pass
 
+
+    return shipping_label
+
+
+#send label to network printer
+@frappe.whitelist()
+def net_print_shipping_label(shipment: str, printer_setting: str):
+    shipment_doc = frappe.get_doc("Shipment", shipment)
+    service_provider = shipment_doc.service_provider
+    shipment_id = shipment_doc.shipment_id
+    shipping_label_url = None
+    is_byte_data = False # for SendCloud — when calling the print_label_from_url it gives a distinction between labels that are in byte array or URL string
+
+    # Fetch the shipping label URL
+    if service_provider == LETMESHIP_PROVIDER:
+        letmeship = get_letmeship_utils()
+        shipping_label_url = letmeship.get_label(shipment_id)
+    elif service_provider == SENDCLOUD_PROVIDER:
+        is_byte_data = True # if the provider is SendCloud tell print_label_from_url that the label is already in an array of bytes
+        sendcloud = SendCloudUtils()
+        _labels = sendcloud.get_label(shipment_id)
+        if _labels:
+            shipping_label_url = sendcloud.download_label(_labels[0])
+    elif service_provider == EASYPOST_PROVIDER:
+        easypost = EasyPostUtils()
+        shipping_label_url = easypost.get_label(shipment_id)
+    elif service_provider == "UPS":
+        # Use the URL we saved on create_shipment
+        shipping_label_url = shipment_doc.get("custom_shipping_label")
+        is_byte_data = False
+
+
+    if not shipping_label_url:
+        frappe.throw(_("No shipping label found for shipment ID: {0}").format(shipment_id))
+
+    # Print the label
+    try:
+        print_label_from_url(shipping_label_url, printer_setting, is_byte_data, shipment)
+
+    except Exception as e:
+        frappe.throw(_("Failed to print the shipping label: {0}").format(str(e)))
+
+    return _("Shipping label sent to printer successfully.")
+
+def print_label_from_url(label: str, printer_setting: str, is_byte_data: bool, shipment: str):
+# Downloads a file from a URL and sends it to the configured network printer.
+    import cups
+
+    # Fetch EasyPost settings
+    easypost_settings = frappe.get_single("Shipping Settings")
+    default_printer = easypost_settings.default_network_printer
+
+    # Fetch printer settings
+    print_settings = frappe.get_doc("Network Printer Settings", printer_setting)
+
+    # Use the default printer if specified; otherwise, fallback to provided printer_setting
+    selected_printer = default_printer if default_printer else printer_setting
+
+    label_content = b''
+    label_filename = ""
+
+    if not selected_printer:
+        frappe.throw(_("No printer selected or configured."))
+
+    # if the label is in bytes, skip downloading from URL, store the label_content and set the filename that are in the arguments
+    if is_byte_data:
+        label_content = label
+        label_filename = f"label_{shipment}.pdf"
+
+    # otherwise, proceed with downloading first
+    else:
+        try:
+            # Download the label from the URL
+            response = requests.get(label)
+            response.raise_for_status()
+
+            # store the content and set the filename
+            label_content = response.content
+            label_filename = label
+
+        except requests.exceptions.RequestException as e:
+            frappe.throw(_("Failed to download the label: {0}").format(e))
+        except cups.IPPError as e:
+            frappe.throw(_("Printing failed due to CUPS error: {0}").format(e))
+        except Exception as e:
+            frappe.throw(_("An error occurred while printing: {0}").format(e))
+
+    # Save the label locally
+    file_name = os.path.basename(label_filename)
+    local_path = os.path.join("/tmp", file_name)
+    with open(local_path, "wb") as f:
+        f.write(label_content)
+
+    # Set up CUPS connection
+    cups.setServer(print_settings.server_ip)
+    cups.setPort(print_settings.port)
+    conn = cups.Connection()
+
+    # Print the file
+    conn.printFile(print_settings.printer_name, local_path, "Shipping Label", {})
+
+    # Clean up the temporary file
+    os.remove(local_path)
 
 def save_label_as_attachment(shipment: str, content: bytes) -> str:
-	"""Store label as attachment to Shipment and return the URL."""
-	attachment = frappe.new_doc("File")
+#Store label as attachment to Shipment and return the URL.
+    attachment = frappe.new_doc("File")
 
-	attachment.file_name = f"label_{shipment}.pdf"
-	attachment.content = content
-	attachment.folder = "Home/Attachments"
-	attachment.attached_to_doctype = "Shipment"
-	attachment.attached_to_name = shipment
-	attachment.is_private = 1
-	attachment.save()
+    attachment.file_name = f"label_{shipment}.pdf"
+    attachment.content = content
+    attachment.folder = "Home/Attachments"
+    attachment.attached_to_doctype = "Shipment"
+    attachment.attached_to_name = shipment
+    attachment.is_private = 1
+    attachment.save()
 
-	return attachment.file_url
-
+    return attachment.file_url
 
 @frappe.whitelist()
 def update_tracking(shipment, service_provider, shipment_id, delivery_notes=None):
-	if delivery_notes is None:
-		delivery_notes = []
+    if delivery_notes is None:
+        delivery_notes = []
 
-	# Update Tracking info in Shipment
-	tracking_data = None
-	if service_provider == LETMESHIP_PROVIDER:
-		letmeship = get_letmeship_utils()
-		tracking_data = letmeship.get_tracking_data(shipment_id)
-	elif service_provider == SENDCLOUD_PROVIDER:
-		sendcloud = SendCloudUtils()
-		tracking_data = sendcloud.get_tracking_data(shipment_id)
+    # Update Tracking info in Shipment
+    tracking_data = None
+    if service_provider == LETMESHIP_PROVIDER:
+        letmeship = get_letmeship_utils()
+        tracking_data = letmeship.get_tracking_data(shipment_id)
+    elif service_provider == SENDCLOUD_PROVIDER:
+        sendcloud = SendCloudUtils()
+        tracking_data = sendcloud.get_tracking_data(shipment_id)
+    elif service_provider == EASYPOST_PROVIDER:
+        easypost = EasyPostUtils()
+        tracking_data = easypost.get_tracking_data(shipment_id)
 
-	if not tracking_data:
-		return
+    if not tracking_data:
+        return
 
-	shipment = frappe.get_doc("Shipment", shipment)
-	shipment.db_set(
-		{
-			"awb_number": tracking_data.get("awb_number"),
-			"tracking_status": tracking_data.get("tracking_status"),
-			"tracking_status_info": tracking_data.get("tracking_status_info"),
-			"tracking_url": tracking_data.get("tracking_url"),
-		}
-	)
+    shipment = frappe.get_doc("Shipment", shipment)
+    shipment.db_set(
+        {
+            "awb_number": tracking_data.get("awb_number"),
+            "tracking_status": tracking_data.get("tracking_status"),
+            "tracking_status_info": tracking_data.get("tracking_status_info"),
+            "tracking_url": tracking_data.get("tracking_url"),
+        }
+    )
 
-	if delivery_notes:
-		update_delivery_note(delivery_notes=delivery_notes, tracking_info=tracking_data)
+    if delivery_notes:
+        update_delivery_note(delivery_notes=delivery_notes, tracking_info=tracking_data)
 
 
 def update_delivery_note(delivery_notes, shipment_info=None, tracking_info=None):
-	# Update Shipment Info in Delivery Note
-	# Using db_set since some services might not exist
-	if isinstance(delivery_notes, str):
-		delivery_notes = json.loads(delivery_notes)
+    # Update Shipment Info in Delivery Note
+    # Using db_set since some services might not exist
+    if isinstance(delivery_notes, str):
+        delivery_notes = json.loads(delivery_notes)
 
-	delivery_notes = list(set(delivery_notes))
+    delivery_notes = list(set(delivery_notes))
 
-	for delivery_note in delivery_notes:
-		dl_doc = frappe.get_doc("Delivery Note", delivery_note)
-		if shipment_info:
-			dl_doc.db_set("delivery_type", "Parcel Service")
-			dl_doc.db_set("parcel_service", shipment_info.get("carrier"))
-			dl_doc.db_set("parcel_service_type", shipment_info.get("carrier_service"))
-		if tracking_info:
-			dl_doc.db_set("tracking_number", tracking_info.get("awb_number"))
-			dl_doc.db_set("tracking_url", tracking_info.get("tracking_url"))
-			dl_doc.db_set("tracking_status", tracking_info.get("tracking_status"))
-			dl_doc.db_set("tracking_status_info", tracking_info.get("tracking_status_info"))
+    for delivery_note in delivery_notes:
+        dl_doc = frappe.get_doc("Delivery Note", delivery_note)
+        if shipment_info:
+            dl_doc.db_set("delivery_type", "Parcel Service")
+            dl_doc.db_set("parcel_service", shipment_info.get("carrier"))
+            dl_doc.db_set("parcel_service_type", shipment_info.get("carrier_service"))
+        if tracking_info:
+            dl_doc.db_set("tracking_number", tracking_info.get("awb_number"))
+            dl_doc.db_set("tracking_url", tracking_info.get("tracking_url"))
+            dl_doc.db_set("tracking_status", tracking_info.get("tracking_status"))
+            dl_doc.db_set("tracking_status_info", tracking_info.get("tracking_status_info"))
+

--- a/erpnext_shipping/erpnext_shipping/shipping.py
+++ b/erpnext_shipping/erpnext_shipping/shipping.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2020, Frappe Technologies and contributors
 # For license information, please see license.txt
+#/apps/erpnext_shipping/erpnext_shipping/erpnext_shipping
 import base64
 import uuid
 import json
@@ -83,7 +84,7 @@ def fetch_shipping_rates(
         sendcloud_prices = match_parcel_service_type_carrier(sendcloud_prices, "carrier", "service_name")
         shipment_prices += sendcloud_prices
 
-    if easypost_enabled and len(parcels) == 1:
+    if easypost_enabled:
         pickup_contact = None
         delivery_contact = None
         if pickup_from_type != "Company":
@@ -292,8 +293,12 @@ def create_shipment(
             except frappe.DoesNotExistError:
                 pass
 
-                if delivery_notes:
-                    update_delivery_note(delivery_notes=delivery_notes, shipment_info=shipment_info)
+        # FETCH delivery_notes from Shipment child table if not provided/empty
+        if not delivery_notes:
+            delivery_notes = [row.delivery_note for row in shipment_doc.get("shipment_delivery_note") or [] if row.delivery_note]
+
+        if delivery_notes:
+            update_delivery_note(delivery_notes=delivery_notes, shipment_info=shipment_info)
 
     return shipment_info
 
@@ -484,8 +489,8 @@ def update_tracking(shipment, service_provider, shipment_id, delivery_notes=None
     if not tracking_data:
         return
 
-    shipment = frappe.get_doc("Shipment", shipment)
-    shipment.db_set(
+    shipment_doc = frappe.get_doc("Shipment", shipment)  # Renamed for clarity
+    shipment_doc.db_set(
         {
             "awb_number": tracking_data.get("awb_number"),
             "tracking_status": tracking_data.get("tracking_status"),
@@ -494,8 +499,20 @@ def update_tracking(shipment, service_provider, shipment_id, delivery_notes=None
         }
     )
 
+    # FETCH delivery_notes from Shipment child table if not provided/empty
+    if not delivery_notes:
+        delivery_notes = [row.delivery_note for row in shipment_doc.get("shipment_delivery_note") or [] if row.delivery_note]
+
+    # CONSTRUCT minimal shipment_info from Shipment doc (fallback)
+    shipment_info = None
+    if delivery_notes:  # Only build if we'll use it
+        shipment_info = {
+            "carrier": shipment_doc.carrier,
+            "carrier_service": shipment_doc.carrier_service,
+        }
+
     if delivery_notes:
-        update_delivery_note(delivery_notes=delivery_notes, tracking_info=tracking_data)
+        update_delivery_note(delivery_notes=delivery_notes, shipment_info=shipment_info, tracking_info=tracking_data)
 
 
 def update_delivery_note(delivery_notes, shipment_info=None, tracking_info=None):
@@ -517,4 +534,3 @@ def update_delivery_note(delivery_notes, shipment_info=None, tracking_info=None)
             dl_doc.db_set("tracking_url", tracking_info.get("tracking_url"))
             dl_doc.db_set("tracking_status", tracking_info.get("tracking_status"))
             dl_doc.db_set("tracking_status_info", tracking_info.get("tracking_status_info"))
-

--- a/erpnext_shipping/public/js/shipment.js
+++ b/erpnext_shipping/public/js/shipment.js
@@ -5,9 +5,21 @@ frappe.ui.form.on("Shipment", {
 	refresh: function (frm) {
 		if (frm.doc.docstatus === 1 && !frm.doc.shipment_id) {
 			frm.add_custom_button(__("Fetch Shipping Rates"), function () {
-				return frm.events.fetch_shipping_rates(frm);
+				if (frm.doc.shipment_parcel.length > 1) {
+					frappe.confirm(
+						__(
+							"If your shipment contains packages with varying weights, the estimated shipping rates may differ from the final price charged by your carrier. Do you wish to proceed?"
+						),
+						function () {
+							frm.events.fetch_shipping_rates(frm);
+						}
+					);
+				} else {
+					frm.events.fetch_shipping_rates(frm);
+				}
 			});
 		}
+
 		if (frm.doc.shipment_id) {
 			frm.add_custom_button(
 				__("Print Shipping Label"),
@@ -15,6 +27,17 @@ frappe.ui.form.on("Shipment", {
 					return frm.events.print_shipping_label(frm);
 				},
 				__("Tools")
+			);
+		}
+
+		if (frm.doc.shipment_id) {
+			frm.add_custom_button(
+				__("Network Print Label"),
+				function () {
+					net_print_shipping_label(frm.doc.name)
+				},
+			
+					__("Tools")
 			);
 			if (frm.doc.tracking_status != "Delivered") {
 				frm.add_custom_button(
@@ -47,6 +70,206 @@ frappe.ui.form.on("Shipment", {
 				);
 			}
 		}
+
+		if (frm.doc.status === "Booked" || frm.doc.status === "Completed") {
+    		frm.add_custom_button(
+    		    "Create Sales Invoice", 
+    		    function() {
+					frappe.call({
+						method: "erpnext_shipping.erpnext_shipping.doctype.shipping_settings.shipping_settings.check_settings_if_complete",
+						freeze: true,
+						freeze_message: "Checking Setttings",
+						callback: function(r) {
+							if (!r.exc) {
+								if (frm.doc.shipment_delivery_note) {
+									frappe.call({
+										method: "erpnext_shipping.erpnext_shipping.doctype.shipping_settings.shipping_settings.find_related_shipments",
+										args: {
+											delivery_note_name: frm.doc.shipment_delivery_note[0].delivery_note,
+											current_shipment: frm.doc.name
+										},
+										callback: function(r) {
+											if (r.message) {
+												let shipments = [
+													{
+														__checked: true,
+														name: frm.doc.name,
+														value_of_goods: frm.doc.value_of_goods,
+														description_of_content: frm.doc.description_of_content, 
+														shipment_amount: frm.doc.shipment_amount, 
+														creation: frm.doc.creation, 
+														shipment_type: frm.doc.shipment_type, 
+														pickup_type: frm.doc.pickup_type
+													},
+													...r.message
+												]
+												let shipment_cost = frm.doc.shipment_amount
+												let additional_fields = []
+												let dialog_size = 'small'
+												let shipment_cost_label = 'Shipment Cost'
+												let shipment_list = []
+
+												if (shipments.length > 1) {
+													dialog_size = 'large'
+													shipment_cost_label = 'Total Shipment Cost'
+													additional_fields =  [
+														{
+															fieldtype: 'Section Break'
+														},
+														{
+															label: 'Additional Message',
+															fieldname: 'additional_message',
+															fieldtype: 'HTML',
+															options: __('There are other shipments similar to this. Would you like to include them to the invoice?<br/><br/>')
+														},
+														{
+															label: 'Related Shipments Table',
+															fieldname: 'related_shipments',
+															fieldtype: 'Table',
+															cannot_add_rows: 1,
+															cannot_delete_rows: 1,
+															cannot_edit_rows: 1,
+															in_place_edit: 0,
+															allow_bulk_edit: 0,
+															data: shipments,
+															fields: [
+																// { 
+																// 	fieldname: 'is_included',
+																// 	fieldtype: 'Check',
+																// 	in_list_view: 1,
+																// 	label: 'Include?'
+																// },
+																{
+																	fieldname: 'name',
+																	fieldtype: 'Link',
+																	in_list_view: true,
+																	label: 'Shipment ID',
+																	options: 'Shipment',
+																	read_only:  1,
+																	columns: 3
+																},
+																{ 
+																	fieldname: 'value_of_goods',
+																	fieldtype: 'Currency',
+																	in_list_view: 1,
+																	label: 'Value',
+																	read_only:  1,
+																	columns: 2
+																},
+																{ 
+																	fieldname: 'description_of_content',
+																	fieldtype: 'Data',
+																	in_list_view: 1,
+																	label: 'Description',
+																	read_only:  1,
+																	columns: 3
+																},
+																{ 
+																	fieldname: 'shipment_amount',
+																	fieldtype: 'Currency',
+																	in_list_view: 1,
+																	label: 'Shipment Amount',
+																	read_only:  1,
+																	columns: 2
+																},
+																{
+																	fieldname: 'creation',
+																	fieldtype: 'Datetime',
+																	label: 'Date Created',
+																	read_only: 1,
+																},
+																{
+																	fieldname: 'shipment_type',
+																	fieldtype: 'Data',
+																	label: 'Shipment Type',
+																	read_only: 1,
+																},
+																{
+																	fieldname: 'pickup_type',
+																	fieldtype: 'Data',
+																	label: 'Pickup Type',
+																	read_only: 1
+																}
+															]
+														},
+														{
+															fieldtype: 'Column Break',
+															fieldname: 'shipping_cost_column'  // Start first column
+														},
+													]
+												}
+
+												let shipping_cost_dialog = new frappe.ui.Dialog({
+													title: __('Add Shipping Cost'),
+													fields: [
+														...additional_fields,
+														{
+															label: shipment_cost_label,
+															fieldname: 'shipment_cost',
+															fieldtype: 'Currency',
+															read_only: 1,
+															default: shipment_cost
+														},
+														{
+															label: 'Handling Fee',
+															fieldname: 'handling_fee',
+															fieldtype: 'Currency',
+															default: 2
+														}
+													],
+													size: dialog_size,
+													primary_action_label: 'Proceed',
+													primary_action: function (values) {
+														frappe.model.open_mapped_doc({
+															method: "erpnext_shipping.erpnext_shipping.doctype.shipping_settings.shipping_settings.make_sales_invoice_from_shipment",
+															frm: frm,
+															args: {
+																delivery_note: frm.doc.shipment_delivery_note[0].delivery_note,
+																shipping_total: values.shipment_cost + (values.handling_fee || 0),
+																shipments: shipment_list
+															},
+															freeze: true,
+															freeze_message: "Creating New Sales Invoice",
+														})
+													}
+												})
+
+												if (shipments.length > 1) {
+													shipping_cost_dialog.$wrapper.find('.modal-dialog').attr('id', 'shipping-cost-modal')
+													shipping_cost_dialog.$wrapper.find('.form-column[data-fieldname="__column_1"]').addClass('col-md-9')
+													shipping_cost_dialog.$wrapper.find('.form-column[data-fieldname="shipping_cost_column"]').addClass('col-md-3')
+													shipping_cost_dialog.$wrapper.find('.panel-title').hide()
+													console.log(shipping_cost_dialog.$wrapper)
+													shipping_cost_dialog.$wrapper.find('use[href="#icon-down"]').attr('href', '#icon-up')
+													shipping_cost_dialog.$wrapper.find('use[href="#icon-edit"]').attr('href', '#icon-down')
+													shipping_cost_dialog.$wrapper.find('div[data-fieldname="related_shipments"] .grid-row input[type="checkbox"]').on('change', function () {
+														let table_data = shipping_cost_dialog.get_value('related_shipments')
+														let selected_shipments = table_data.filter(row => row.__checked)
+														let shipment_sum = selected_shipments.reduce((sum, shipment) => sum + shipment.shipment_amount, 0)
+														shipment_list = selected_shipments.map(shipment => shipment.name)
+														console.log(shipment_list)
+														shipping_cost_dialog.set_value('shipment_cost', shipment_sum)
+													})
+												}
+												
+												shipping_cost_dialog.show()
+											}
+										}
+									})
+								}
+								else {
+									frappe.msgprint({
+										title: "Can't Create Sales Invoice",
+										indicator: "orange",
+										message: "The shipment doesn't have a delivery note associated with it."
+									});
+								}
+							}
+						}
+					})
+    		    }
+    		)
+	    }
 	},
 
 	fetch_shipping_rates: function (frm) {
@@ -133,13 +356,279 @@ frappe.ui.form.on("Shipment", {
 			callback: function (r) {
 				if (!r.exc) {
 					frm.reload_doc();
+					$('div[data-fieldname="shipment_information_section"]')[0].scrollIntoView();
 				}
 			},
 		});
 	},
+
+	before_submit: async (frm) => {
+		let shipping_settings = await get_shipping_settings()
+		function show_rates_error(message) {
+			frappe.throw(message)
+		}
+
+		async function show_parcel_count_warning(m) {
+			if (shipping_settings.flag_multiple_parcels) {
+				let prompt = new Promise((resolve, reject) => {
+					frappe.confirm(
+						`The shipment has <b>${frm.doc.shipment_parcel.length}</b> parcels.\n EasyPost will not appear in the rates table as it does not support multiple parcels. Continue anyways?</b>`,
+						() => resolve(),
+						() => reject()
+					);
+				});
+				await prompt.then(
+					() => frappe.show_alert("Shipment successfully submitted.", 5), 
+					() => {
+						frappe.validated = false
+						frappe.show_alert("Shipment submission cancelled.", 5)
+					}
+				);
+			}
+			else {
+				frm.save('Submit')
+			}
+		}
+
+		async function verify_address() {
+			let address_name = frm.doc.delivery_address_name
+
+			const addition_dialog_fields = [
+				{
+					fieldtype: "HTML",
+					fieldname: "message_line2",
+					options: __("<div id='mark-message' class='alert alert-warning small'><div style='margin-bottom: 0.5rem'>If you believe the customer address is correct, tick the checkbox below to avoid this message in the future.</div></div>")
+				},
+				{
+					fieldtype: "Check",
+					fieldname: "mark_as_verified",
+					label: "Mark as verified",
+					default: 0
+				}
+			]
+
+			function update_address(data_map, verify_address = false, freeze_message = null) {
+				let freeze_options = 
+					freeze_message? 
+						{
+							freeze: true,
+							freeze_message: __(freeze_message),
+						}
+					:
+						{}
+				frappe.call({
+					method: "erpnext_shipping.erpnext_shipping.doctype.shipping_settings.shipping_settings.update_address",
+					args: {
+						address_name: address_name,
+						data_map: data_map,
+						do_verify_address: verify_address
+					},
+					...freeze_options
+				})
+			}
+
+			if (shipping_settings.verify_address) {
+				frappe.call({
+					method: "erpnext_shipping.erpnext_shipping.doctype.shipping_settings.shipping_settings.verify_address",
+						freeze: true,
+						args: {
+							address_name: address_name
+						},
+						callback: function(r) {
+							if(r.message && r.message.result === "Mismatched") {
+								frappe.validated = false
+								const mismatch_dialog = new frappe.ui.Dialog({
+									title: __("Address Mismatch Found"),
+									size: "medium",
+									fields: [
+										{
+											fieldtype: "HTML",
+											fieldname: "message",
+											options: r.message.notes + "<br/><br/>",
+										},
+										...addition_dialog_fields
+									],
+									primary_action_label: __("Submit Anyway"),
+									primary_action: (values) => {
+										if (values.mark_as_verified) {
+											update_address({"is_verified": 1}, false)
+										}
+										frm.save('Submit')
+										mismatch_dialog.hide()
+									},
+								})
+	
+								mismatch_dialog.set_secondary_action_label(__("Fix Address"))
+								mismatch_dialog.set_secondary_action(() => {
+									update_address(r.message.data, true, "Fixing Address")
+									frm.set_value('delivery_address_name', '')
+									setTimeout(function() {
+										frm.set_value('delivery_address_name', address_name)
+										frm.save()
+										frm.scroll_to_field('delivery_address')
+									} , 1500)
+									mismatch_dialog.hide()
+								})
+		
+								mismatch_dialog.show()
+								mismatch_dialog.$wrapper.find('div[data-fieldname="mark_as_verified"]').appendTo(mismatch_dialog.$wrapper.find('div[id="mark-message"]'))
+							}
+							else if(r.message && r.message.result === "Fail") {
+								frappe.validated = false
+								const fail_dialog = new frappe.ui.Dialog({
+									title: __("Address Not Found"),
+									size: "medium",
+									fields: [
+										{
+											fieldtype: "HTML",
+											fieldname: "message_line1",
+											options: __("The address was not found at EasyPost. To ignore this warning, click Submit Anyway.<br/><br/>")
+										},
+										...addition_dialog_fields
+									],
+									primary_action_label: __("Submit Anyway"),
+									primary_action: (values) => {
+										if (values.mark_as_verified) {
+											update_address({"is_verified": 1}, false)
+										}
+										frm.save('Submit')
+										fail_dialog.hide()
+									},
+								})
+								fail_dialog.show()
+
+								fail_dialog.$wrapper.find('div[data-fieldname="mark_as_verified"]').appendTo(fail_dialog.$wrapper.find('div[id="mark-message"]'))
+							}
+						}
+				})
+			}
+			else {
+				let prompt = new Promise((resolve, reject) => {
+					frappe.confirm(
+						"The address isn't verified. Continue anyways?",
+						() => resolve(),
+						() => reject()
+					);
+				});
+				await prompt.then(
+					() => {
+						prompt.hide()
+						frm.save('Submit')
+					},
+					() => {
+						prompt.hide()
+						frappe.validated = false
+						frappe.show_alert({
+							message: "Shipment purchase was cancelled.",
+							indicator: "red" 
+						}, 7)
+					}
+				)
+			}
+
+		}
+			
+		frappe.call({
+			method: "erpnext_shipping.erpnext_shipping.doctype.shipping_settings.shipping_settings.validate_submission",
+			args: {
+				shipment_name: frm.doc.name,
+				address_name: frm.doc.delivery_address_name
+			},
+			freeze: true,
+			freeze_message: __("Submitting Shipment"),
+			callback: function(r) {
+				let response = r.message
+				if (response && response.status !== "validated") {
+					frappe.validated = false
+					if (response.error_type === "digest") {
+						frappe.msgprint({
+							title: __("Submission Halted"),
+							indicator: "orange",
+							message: __(response.error_messages),
+							wide: true
+						})
+					}
+					else {
+						if (response.error_list.includes("currency_not_set")) {
+							show_rates_error(response.error_messages.currency_not_set)
+						}
+
+						if (response.error_list.includes("multiple_parcels")) {
+							show_parcel_count_warning()
+						}
+
+						if (response.error_list.includes("unverified_address")) {
+							verify_address()
+						}
+					}
+				}
+			}
+		})
+	}
 });
 
-function select_from_available_services(frm, available_services) {
+async function get_shipping_settings() {
+	return response = await new Promise((resolve, reject) => {
+		frappe.call({
+			method: "frappe.client.get",
+			args: {
+				doctype: "Shipping Settings"
+			},
+			callback: function(r) {
+				if (!r.exc) resolve(r.message);
+                else reject(r.exc);
+			}
+		})
+	})
+}
+
+async function net_print_shipping_label(shipment_name) {
+	function print_label(selected_printer) {
+		frappe.call({
+			method: "erpnext_shipping.erpnext_shipping.shipping.net_print_shipping_label",
+			args: {
+				shipment: shipment_name,
+				printer_setting: selected_printer,
+			},
+			callback: function (res) {
+				if (!res.exc) {
+					frappe.msgprint(
+						__("Shipping label sent to printer successfully.")
+					);
+				}
+			},
+		});
+	} 
+
+	// Fetch Shipping settings to check for default_network_printer
+	// Mark changed Easypost to Shipping Settings
+	let shipping_settings = await get_shipping_settings()
+
+	if (shipping_settings.default_network_printer) {
+		// Default printer exists, skip the dialog
+		print_label(shipping_settings.default_network_printer)
+	} else {
+		// No default printer, show dialog to select printer
+		frappe.prompt(
+			[
+				{
+					label: __("Printer Setting"),
+					fieldname: "printer_setting",
+					fieldtype: "Link",
+					options: "Network Printer Settings",
+					reqd: 1,
+				},
+			],
+			function (values) {
+				print_label(values.printer_setting)
+			},
+			__("Select Printer Setting"),
+			__("Print")
+		);
+	}
+}
+
+async function select_from_available_services(frm, available_services) {
 	const arranged_services = available_services.reduce(
 		(prev, curr) => {
 			if (curr.is_preferred) {
@@ -152,7 +641,7 @@ function select_from_available_services(frm, available_services) {
 		{ preferred_services: [], other_services: [] }
 	);
 
-	const dialog = new frappe.ui.Dialog({
+	const select_dialog = new frappe.ui.Dialog({
 		title: __("Select Service to Create Shipment"),
 		size: "extra-large",
 		fields: [
@@ -169,14 +658,18 @@ function select_from_available_services(frm, available_services) {
 		delivery_notes.push(d.delivery_note);
 	});
 
-	dialog.fields_dict.available_services.$wrapper.html(
-		frappe.render_template("shipment_service_selector", {
-			header_columns: [__("Platform"), __("Carrier"), __("Parcel Service"), __("Price"), ""],
-			data: arranged_services,
-		})
+	let shipping_settings = await get_shipping_settings()
+
+	select_dialog.fields_dict.available_services.$wrapper.html(
+	  frappe.render_template("shipment_service_selector", {
+		header_columns: [__("Platform"), __("Carrier"), __("Parcel Service"), __("Days"), __("Price"), ""],
+		data: arranged_services,
+		rates_currency: shipping_settings.rates_currency
+	  })
 	);
 
-	dialog.$body.on("click", ".btn", function () {
+
+	select_dialog.$body.on("click", ".btn", function () {
 		let service_type = $(this).attr("data-type");
 		let service_index = cint($(this).attr("id").split("-")[2]);
 		let service_data = arranged_services[service_type][service_index];
@@ -184,6 +677,7 @@ function select_from_available_services(frm, available_services) {
 	});
 
 	frm.select_row = function (service_data) {
+
 		frappe.call({
 			method: "erpnext_shipping.erpnext_shipping.shipping.create_shipment",
 			freeze: true,
@@ -222,10 +716,12 @@ function select_from_available_services(frm, available_services) {
 						r.message.service_provider,
 						r.message.shipment_id
 					);
+					net_print_shipping_label(frm.doc.name);
 				}
 			},
 		});
-		dialog.hide();
+		select_dialog.hide();
+
 	};
-	dialog.show();
+	select_dialog.show();
 }

--- a/erpnext_shipping/public/js/shipment.js
+++ b/erpnext_shipping/public/js/shipment.js
@@ -5,18 +5,7 @@ frappe.ui.form.on("Shipment", {
 	refresh: function (frm) {
 		if (frm.doc.docstatus === 1 && !frm.doc.shipment_id) {
 			frm.add_custom_button(__("Fetch Shipping Rates"), function () {
-				if (frm.doc.shipment_parcel.length > 1) {
-					frappe.confirm(
-						__(
-							"If your shipment contains packages with varying weights, the estimated shipping rates may differ from the final price charged by your carrier. Do you wish to proceed?"
-						),
-						function () {
-							frm.events.fetch_shipping_rates(frm);
-						}
-					);
-				} else {
-					frm.events.fetch_shipping_rates(frm);
-				}
+				frm.events.fetch_shipping_rates(frm);
 			});
 		}
 
@@ -368,26 +357,8 @@ frappe.ui.form.on("Shipment", {
 			frappe.throw(message)
 		}
 
-		async function show_parcel_count_warning(m) {
-			if (shipping_settings.flag_multiple_parcels) {
-				let prompt = new Promise((resolve, reject) => {
-					frappe.confirm(
-						`The shipment has <b>${frm.doc.shipment_parcel.length}</b> parcels.\n EasyPost will not appear in the rates table as it does not support multiple parcels. Continue anyways?</b>`,
-						() => resolve(),
-						() => reject()
-					);
-				});
-				await prompt.then(
-					() => frappe.show_alert("Shipment successfully submitted.", 5), 
-					() => {
-						frappe.validated = false
-						frappe.show_alert("Shipment submission cancelled.", 5)
-					}
-				);
-			}
-			else {
-				frm.save('Submit')
-			}
+		async function show_parcel_count_warning() {
+			frm.save('Submit');
 		}
 
 		async function verify_address() {

--- a/erpnext_shipping/public/js/shipment_service_selector.html
+++ b/erpnext_shipping/public/js/shipment_service_selector.html
@@ -13,15 +13,16 @@
 				<tbody>
 					{% for (var i = 0; i < data.preferred_services.length; i++) { %}
 						<tr id="data-preferred-{{i}}">
-							<td class="service-info" style="width:20%;">{{ data.preferred_services[i].service_provider }}</td>
-							<td class="service-info" style="width:20%;">{{ data.preferred_services[i].carrier }}</td>
-							<td class="service-info" style="width:40%;">{{ data.preferred_services[i].service_name }}</td>
-							<td class="service-info" style="width:20%;">{{ format_currency(data.preferred_services[i].total_price, "EUR", 2) }}</td>
+							<td class="service-info" style="width:15%;">{{ data.preferred_services[i].service_provider }}</td>
+							<td class="service-info" style="width:15%;">{{ data.preferred_services[i].carrier }}</td>
+							<td class="service-info" style="width:35%;">{{ data.preferred_services[i].service_name }}</td>
+							<td class="service-info" style="width:10%;">{{ data.preferred_services[i].delivery_days || "" }}</td>
+							<td class="service-info" style="width:15%;">{{ format_currency(data.preferred_services[i].total_price, rates_currency, 2) }}</td>
 							<td style="width:10%;vertical-align: middle;">
 								<button
 									data-type="preferred_services"
 									id="data-preferred-{{i}}" type="button" class="btn">
-									{{ __("Select") }}
+									{{ __("Buy") }}
 								</button>
 							</td>
 						</tr>
@@ -48,15 +49,16 @@
 				<tbody>
 					{% for (var i = 0; i < data.other_services.length; i++) { %}
 						<tr id="data-other-{{i}}">
-							<td class="service-info" style="width:20%;">{{ data.other_services[i].service_provider }}</td>
-							<td class="service-info" style="width:20%;">{{ data.other_services[i].carrier }}</td>
-							<td class="service-info" style="width:40%;">{{ data.other_services[i].service_name }}</td>
-							<td class="service-info" style="width:20%;">{{ format_currency(data.other_services[i].total_price, "EUR", 2) }}</td>
+							<td class="service-info" style="width:15%;">{{ data.other_services[i].service_provider }}</td>
+							<td class="service-info" style="width:15%;">{{ data.other_services[i].carrier }}</td>
+							<td class="service-info" style="width:35%;">{{ data.other_services[i].service_name }}</td>
+							<td class="service-info" style="width:10%;">{{ data.other_services[i].delivery_days || "" }}</td>
+							<td class="service-info" style="width:15%;">{{ format_currency(data.other_services[i].total_price, rates_currency, 2) }}</td>
 							<td style="width:10%;vertical-align: middle;">
 								<button
 									data-type="other_services"
 									id="data-other-{{i}}" type="button" class="btn">
-									{{ __("Select") }}
+									{{ __("Buy") }}
 								</button>
 							</td>
 						</tr>


### PR DESCRIPTION
1. Added FedEx & UPS 3rd party billing support
2. UPS 3rd party billing must go through user's UPS account as EasyPost does not support UPS 3rd party billing
3. UPS 3rd party billing label gets saved as a png within erpNext
4. When entering a FedEx account number or UPS account number for 3rd party billing, only the corresponding services are shown
5. Added estimated "Days" to each shipping option in the UI

Todo: 
-Add the 5 extra custom fields into the shipment doctype natively
-Add fields to the EasyPost doctype so user can enter their UPS credentials there instead of directly into the python file
-Add the ability to turn 3rd party billing on/off in UI
